### PR TITLE
Repository Plugins

### DIFF
--- a/lib/esse/index/plugins.rb
+++ b/lib/esse/index/plugins.rb
@@ -11,13 +11,22 @@ module Esse
         unless @plugins.include?(mod)
           @plugins << mod
           mod.apply(self, **kwargs, &block) if mod.respond_to?(:apply)
-          extend(mod::ClassMethods) if mod.const_defined?(:ClassMethods, false)
+          extend(mod::IndexClassMethods) if mod.const_defined?(:IndexClassMethods, false)
+          if mod.const_defined?(:RepositoryClassMethods, false)
+            repo_hash.each_value.each { |repo| repository_plugin_extend(repo, mod::RepositoryClassMethods) }
+          end
         end
 
         mod.configure(self, **kwargs, &block) if mod.respond_to?(:configure)
       end
 
       private
+
+      def repository_plugin_extend(repo_class, mod)
+        return if repo_class.singleton_class.included_modules.include?(mod)
+
+        repo_class.extend(mod)
+      end
 
       def load_plugin_module(name)
         module_name = Hstring.new(name)

--- a/lib/esse/index/type.rb
+++ b/lib/esse/index/type.rb
@@ -48,8 +48,13 @@ module Esse
         repo_class.send(:define_singleton_method, :index) { index }
         repo_class.send(:define_singleton_method, :repo_name) { repo_name.to_s }
         repo_class.document_type = repo_name.to_s
-
         repo_class.class_eval(&block) if block
+
+        plugins.each do |mod|
+          next unless mod.const_defined?(:RepositoryClassMethods, false)
+
+          repository_plugin_extend(repo_class, mod::RepositoryClassMethods)
+        end
 
         self.repo_hash = repo_hash.merge(repo_class.repo_name => repo_class)
         repo_class

--- a/spec/esse/index/plugins_spec.rb
+++ b/spec/esse/index/plugins_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe Esse::Index, '.plugin' do
     }.to raise_error(LoadError)
   end
 
-  it 'extends the index with ClassMethods of the plugin' do
+  it 'extends the index with IndexClassMethods of the plugin' do
     plug = Module.new do
-      self::ClassMethods = Module.new do
+      self::IndexClassMethods = Module.new do
         def foo
           :foo
         end
@@ -24,6 +24,56 @@ RSpec.describe Esse::Index, '.plugin' do
     klass.plugin(plug)
     expect(klass.plugins).to include(plug)
     expect(klass.foo).to eq(:foo)
+  end
+
+  it 'extends the index repository with RepositoryClassMethods of the plugin' do
+    plug = Module.new do
+      self::RepositoryClassMethods = Module.new do
+        def bar
+          :bar
+        end
+      end
+    end
+    klass = Class.new(Esse::Index)
+    klass.repository(:foo)
+    expect(klass.repo(:foo)).not_to respond_to(:bar)
+    klass.plugin(plug)
+    expect(klass.repo(:foo)).to respond_to(:bar)
+    expect(klass.repo(:foo).bar).to eq(:bar)
+  end
+
+  it 'extends new repositories with RepositoryClassMethods even plugin previously loaded' do
+    plug = Module.new do
+      self::RepositoryClassMethods = Module.new do
+        def bar
+          :bar
+        end
+      end
+    end
+    klass = Class.new(Esse::Index) do
+      plugin(plug)
+    end
+    klass.repository(:foo)
+    expect(klass.repo(:foo)).to respond_to(:bar)
+    expect(klass.repo(:foo).bar).to eq(:bar)
+  end
+
+  it 'does not extend repositories multiple types with the same plugin' do
+    plug = Module.new do
+      self::RepositoryClassMethods = Module.new do
+        def bar
+          :bar
+        end
+      end
+    end
+    klass = Class.new(Esse::Index) do
+      repository(:one)
+      plugin(plug)
+    end
+    expect(klass.repo(:one)).to respond_to(:bar)
+    expect(klass.repo(:one)).not_to receive(:extend).with(plug::RepositoryClassMethods)
+    klass.repository(:two)
+    expect(klass.repo(:two)).to respond_to(:bar)
   end
 
   it 'calls apply and configure on the plugin' do
@@ -70,12 +120,12 @@ RSpec.describe Esse::Index, '.plugin' do
 
   it 'should have inherited_instance_variables add instance variables to copy into the subclass' do
     plug = Module.new do
-      def self.apply(model)
-        model.instance_variable_set(:@plugin_domain, 'foo')
+      def self.apply(index_class)
+        index_class.instance_variable_set(:@plugin_domain, 'foo')
       end
 
       # rubocop:disable Lint/ConstantDefinitionInBlock
-      module self::ClassMethods
+      module self::IndexClassMethods
         attr_reader :plugin_domain
 
         Esse::Plugins.inherited_instance_variables(self, :@plugin_domain => :dup)


### PR DESCRIPTION
Repository should be extended with the `RepositoryClassMethods` module of plugins.

Example:
```ruby

module Esse
  module Plugins
    module Foo
      module RepositoryClassMethods
        def foo
          puts "Foo"
        end
      end
    end
  end
end

class MyIndex < Esse::Index
  plugin Esse::Plugins::Foo

  repository :example
end

MyIndex.repo(:example).foo

```