### PR TITLE
Pagy search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.2.4 - 2023-11-15
+* Add `limit` method to the `Esse::Search::Query` class
+* Add `offset` method to the `Esse::Search::Query` class
+* Add `limit_value` method to the `Esse::Search::Query` class
+* Add `offset_value` method to the `Esse::Search::Query` class
+* Expose `cluster` method to the `Esse` module as a shortcut to `Esse.config.cluster`
+* Add `deep_dup` method to the `Esse::HashUtils` module
+* Move pagination and mutation related methods to a new mixin `Esse::Search::Query::DSL`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    esse (0.2.3)
+    esse (0.2.4)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-1.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-1.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.2.2)
+    esse (0.2.4)
       multi_json
       thor (>= 0.19)
 
@@ -75,7 +75,7 @@ GEM
     standard (1.3.0)
       rubocop (= 1.20.0)
       rubocop-performance (= 1.11.5)
-    thor (1.2.1)
+    thor (1.3.0)
     unicode-display_width (2.1.0)
     webmock (3.14.0)
       addressable (>= 2.8.0)
@@ -103,4 +103,4 @@ DEPENDENCIES
   yard (~> 0.9.20)
 
 BUNDLED WITH
-   2.3.21
+   2.3.22

--- a/gemfiles/Gemfile.elasticsearch-2.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-2.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.2.2)
+    esse (0.2.4)
       multi_json
       thor (>= 0.19)
 
@@ -88,7 +88,7 @@ GEM
     standard (1.3.0)
       rubocop (= 1.20.0)
       rubocop-performance (= 1.11.5)
-    thor (1.2.1)
+    thor (1.3.0)
     unicode-display_width (2.0.0)
     webmock (3.14.0)
       addressable (>= 2.8.0)
@@ -115,4 +115,4 @@ DEPENDENCIES
   yard (~> 0.9.20)
 
 BUNDLED WITH
-   2.3.21
+   2.3.22

--- a/gemfiles/Gemfile.elasticsearch-5.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-5.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.2.2)
+    esse (0.2.4)
       multi_json
       thor (>= 0.19)
 
@@ -88,7 +88,7 @@ GEM
     standard (1.3.0)
       rubocop (= 1.20.0)
       rubocop-performance (= 1.11.5)
-    thor (1.2.1)
+    thor (1.3.0)
     unicode-display_width (2.0.0)
     webmock (3.14.0)
       addressable (>= 2.8.0)
@@ -115,4 +115,4 @@ DEPENDENCIES
   yard (~> 0.9.20)
 
 BUNDLED WITH
-   2.3.21
+   2.3.22

--- a/gemfiles/Gemfile.elasticsearch-6.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-6.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.2.2)
+    esse (0.2.4)
       multi_json
       thor (>= 0.19)
 
@@ -88,7 +88,7 @@ GEM
     standard (1.3.0)
       rubocop (= 1.20.0)
       rubocop-performance (= 1.11.5)
-    thor (1.2.1)
+    thor (1.3.0)
     unicode-display_width (2.0.0)
     webmock (3.14.0)
       addressable (>= 2.8.0)
@@ -115,4 +115,4 @@ DEPENDENCIES
   yard (~> 0.9.20)
 
 BUNDLED WITH
-   2.3.21
+   2.3.22

--- a/gemfiles/Gemfile.elasticsearch-7.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-7.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.2.3)
+    esse (0.2.4)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-8.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-8.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.2.2)
+    esse (0.2.4)
       multi_json
       thor (>= 0.19)
 
@@ -97,7 +97,7 @@ GEM
     standard (1.12.1)
       rubocop (= 1.29.1)
       rubocop-performance (= 1.13.3)
-    thor (1.2.1)
+    thor (1.3.0)
     unicode-display_width (2.1.0)
     webmock (3.14.0)
       addressable (>= 2.8.0)
@@ -127,4 +127,4 @@ DEPENDENCIES
   yard (~> 0.9.20)
 
 BUNDLED WITH
-   2.3.21
+   2.3.22

--- a/gemfiles/Gemfile.opensearch-1.x.lock
+++ b/gemfiles/Gemfile.opensearch-1.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.2.2)
+    esse (0.2.4)
       multi_json
       thor (>= 0.19)
 
@@ -79,7 +79,7 @@ GEM
     standard (1.16.1)
       rubocop (= 1.35.1)
       rubocop-performance (= 1.14.3)
-    thor (1.2.2)
+    thor (1.3.0)
     unicode-display_width (2.3.0)
     webmock (3.18.1)
       addressable (>= 2.8.0)
@@ -108,4 +108,4 @@ DEPENDENCIES
   yard (~> 0.9.20)
 
 BUNDLED WITH
-   2.3.21
+   2.3.22

--- a/gemfiles/Gemfile.opensearch-2.x.lock
+++ b/gemfiles/Gemfile.opensearch-2.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.2.2)
+    esse (0.2.4)
       multi_json
       thor (>= 0.19)
 
@@ -97,7 +97,7 @@ GEM
     standard (1.12.1)
       rubocop (= 1.29.1)
       rubocop-performance (= 1.13.3)
-    thor (1.2.1)
+    thor (1.3.0)
     unicode-display_width (2.2.0)
     webmock (3.14.0)
       addressable (>= 2.8.0)
@@ -127,4 +127,4 @@ DEPENDENCIES
   yard (~> 0.9.20)
 
 BUNDLED WITH
-   2.3.21
+   2.3.22

--- a/lib/esse/cluster.rb
+++ b/lib/esse/cluster.rb
@@ -4,6 +4,12 @@ require_relative 'cluster_engine'
 require_relative 'transport'
 
 module Esse
+  class << self
+    extend Forwardable
+
+    def_delegators :config, :cluster
+  end
+
   class Cluster
     ATTRIBUTES = %i[index_prefix settings mappings client wait_for_status readonly].freeze
     WAIT_FOR_STATUSES = %w[green yellow red].freeze
@@ -133,7 +139,7 @@ module Esse
     end
 
     def engine
-      @engine ||=ClusterEngine.new(**info)
+      @engine ||= ClusterEngine.new(**info)
     end
     alias_method :warm_up!, :engine
 

--- a/lib/esse/index/search.rb
+++ b/lib/esse/index/search.rb
@@ -6,6 +6,13 @@ module Esse
       # @param query_or_payload [String,Hash] The search request definition or query in the Lucene query string syntax
       # @param kwargs [Hash] The options to pass to the search.
       def search(*args, &block)
+        kwargs = extract_search_options!(args)
+        cluster.search(self, **kwargs, &block)
+      end
+
+      private
+
+      def extract_search_options!(args)
         query_or_payload = args.shift
         kwargs = args.last.is_a?(Hash) ? args.pop : {}
 
@@ -18,7 +25,7 @@ module Esse
         elsif query_or_payload.is_a?(String)
           kwargs[:q] = query_or_payload
         end
-        cluster.search(self, **kwargs, &block)
+        kwargs
       end
     end
 

--- a/lib/esse/primitives/hash_utils.rb
+++ b/lib/esse/primitives/hash_utils.rb
@@ -6,6 +6,17 @@ module Esse
   module HashUtils
     module_function
 
+    def deep_dup(hash)
+      hash.each_with_object({}) do |(key, value), result|
+        result[key] = \
+          if value.is_a?(Hash)
+            deep_dup(value)
+          else
+            value
+          end
+      end
+    end
+
     def deep_transform_keys(hash, &block)
       hash.each_with_object({}) do |(key, value), result|
         result[yield(key)] = \

--- a/lib/esse/search/query.rb
+++ b/lib/esse/search/query.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+require_relative 'query/dsl'
 module Esse
   module Search
     class Query
+      include DSL
       attr_reader :transport, :definition
 
       # @param transport [Esse::Transport] The client proxy to use for the query
@@ -11,7 +13,7 @@ module Esse
       def initialize(transport, *indices, suffix: nil, **definition, &_block)
         @transport = transport
         @definition = definition
-        @definition[:index] = self.class.normalize_indices(*indices, suffix: suffix)
+        @definition[:index] = self.class.normalize_indices(*indices, suffix: suffix) if indices.any?
       end
 
       def self.normalize_indices(*indices, suffix: nil)
@@ -95,14 +97,6 @@ module Esse
 
       def reset!
         @response = nil
-      end
-
-      def raw_limit_value
-        definition.dig(:body, :size) || definition.dig(:body, 'size') || definition.dig(:size) || definition.dig('size')
-      end
-
-      def raw_offset_value
-        definition.dig(:body, :from) || definition.dig(:body, 'from') || definition.dig(:from) || definition.dig('from')
       end
     end
   end

--- a/lib/esse/search/query.rb
+++ b/lib/esse/search/query.rb
@@ -13,7 +13,7 @@ module Esse
       def initialize(transport, *indices, suffix: nil, **definition, &_block)
         @transport = transport
         @definition = definition
-        @definition[:index] = self.class.normalize_indices(*indices, suffix: suffix) if indices.any?
+        @definition[:index] = self.class.normalize_indices(*indices, suffix: suffix) if indices.size > 0
       end
 
       def self.normalize_indices(*indices, suffix: nil)

--- a/lib/esse/search/query.rb
+++ b/lib/esse/search/query.rb
@@ -11,7 +11,11 @@ module Esse
       def initialize(transport, *indices, suffix: nil, **definition, &_block)
         @transport = transport
         @definition = definition
-        @definition[:index] = indices.map do |index|
+        @definition[:index] = self.class.normalize_indices(*indices, suffix: suffix)
+      end
+
+      def self.normalize_indices(*indices, suffix: nil)
+        indices.map do |index|
           if index.is_a?(Class) && index < Esse::Index
             index.index_name(suffix: suffix)
           elsif index.is_a?(String) || index.is_a?(Symbol)

--- a/lib/esse/search/query/dsl.rb
+++ b/lib/esse/search/query/dsl.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Esse
+  module Search
+    class Query
+      module DSL
+        def limit(value)
+          return self if value.to_i <= 0
+
+          mutate do |defn|
+            defn.delete(:size)
+            if (body = defn[:body]).is_a?(Hash)
+              body[body.key?('size') ? 'size' : :size] = value.to_i
+            else
+              defn.update(size: value.to_i)
+            end
+          end
+        end
+
+        def offset(value)
+          return self if value.to_i < 0
+
+          mutate do |defn|
+            defn.delete(:from)
+            if (body = defn[:body]).is_a?(Hash)
+              body[body.key?('from') ? 'from' : :from] = value.to_i
+            else
+              defn.update(from: value.to_i)
+            end
+          end
+        end
+
+        def limit_value
+          raw_limit_value || 10
+        end
+
+        def offset_value
+          raw_offset_value || 0
+        end
+
+        private
+
+        def mutate
+          relation = clone
+          if block_given? && (new_query = yield(relation.definition)).is_a?(Hash)
+            relation.instance_variable_set(:@definition, new_query)
+          end
+          relation
+        end
+
+        def clone
+          self.class.new(transport, **HashUtils.deep_dup(definition))
+        end
+
+        def raw_limit_value
+          definition.dig(:body, :size) || definition.dig(:body, 'size') || definition.dig(:size) || definition.dig('size')
+        end
+
+        def raw_offset_value
+          definition.dig(:body, :from) || definition.dig(:body, 'from') || definition.dig(:from) || definition.dig('from')
+        end
+      end
+    end
+  end
+end

--- a/lib/esse/search/query/dsl.rb
+++ b/lib/esse/search/query/dsl.rb
@@ -40,16 +40,12 @@ module Esse
 
         private
 
-        def mutate
+        def mutate(&block)
           relation = clone
-          if block_given? && (new_query = yield(relation.definition)).is_a?(Hash)
-            relation.instance_variable_set(:@definition, new_query)
-          end
+          relation.send(:reset!)
+          relation.instance_variable_set(:@definition, HashUtils.deep_dup(definition))
+          relation.instance_exec(relation.definition, &block) if block
           relation
-        end
-
-        def clone
-          self.class.new(transport, **HashUtils.deep_dup(definition))
         end
 
         def raw_limit_value

--- a/lib/esse/version.rb
+++ b/lib/esse/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Esse
-  VERSION = '0.2.3'
+  VERSION = '0.2.4'
 end

--- a/spec/esse/search/query/dsl_spec.rb
+++ b/spec/esse/search/query/dsl_spec.rb
@@ -1,0 +1,339 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Esse::Search::Query, 'dsl' do
+  describe '#limit_value' do
+    subject { described_class.new(Class.new(Esse::Index), **params).limit_value }
+
+    let(:params) { {} }
+
+    it 'returns 10 by default' do
+      is_expected.to eq(10)
+    end
+
+    context 'when definition have [:body][:size] value' do
+      let(:params) do
+        {
+          body: {
+            size: 100
+          }
+        }
+      end
+
+      it { is_expected.to eq(100) }
+    end
+
+    context 'when definition have [:body]["size"] value' do
+      let(:params) do
+        {
+          body: {
+            'size' => 100
+          }
+        }
+      end
+
+      it { is_expected.to eq(100) }
+    end
+
+    context 'when params have the :size' do
+      let(:params) { { size: 20 } }
+
+      it { is_expected.to eq(20) }
+    end
+  end
+
+  describe '#offset_value' do
+    subject { described_class.new(Class.new(Esse::Index), **params).offset_value }
+
+    let(:params) { {} }
+
+    it 'returns 0 by default' do
+      is_expected.to eq(0)
+    end
+
+    context 'when definition have [:body][:from] value' do
+      let(:params) do
+        {
+          body: {
+            from: 100
+          }
+        }
+      end
+
+      it { is_expected.to eq(100) }
+    end
+
+    context 'when definition have [:body]["from"] value' do
+      let(:params) do
+        {
+          body: {
+            'from' => 100
+          }
+        }
+      end
+
+      it { is_expected.to eq(100) }
+    end
+
+    context 'when params have the :from' do
+      let(:params) { { from: 20 } }
+
+      it { is_expected.to eq(20) }
+    end
+  end
+
+  describe '#raw_limit_value' do
+    subject { described_class.new(Class.new(Esse::Index), **params).send(:raw_limit_value) }
+
+    let(:params) { {} }
+
+    it { is_expected.to eq(nil) }
+
+    context 'when definition have [:body][:size] value' do
+      let(:params) do
+        {
+          body: {
+            size: 10
+          }
+        }
+      end
+
+      it { is_expected.to eq(10) }
+    end
+
+    context 'when definition have [:body]["size"] value' do
+      let(:params) do
+        {
+          body: {
+            'size' => 10
+          }
+        }
+      end
+
+      it { is_expected.to eq(10) }
+    end
+
+    context 'when params have the :size' do
+      let(:params) { { size: 20 } }
+
+      it { is_expected.to eq(20) }
+    end
+  end
+
+  describe '#limit' do
+    let(:query) { described_class.new(Class.new(Esse::Index), **params) }
+    let(:params) { {} }
+
+    it 'returns a new query' do
+      expect { query.limit(20) }.not_to change { query.definition }
+      expect(query.limit(20)).to be_a(described_class)
+    end
+
+    it 'sets the limit value' do
+      expect(query.limit(20).limit_value).to eq(20)
+    end
+
+    it 'sets the limit value as an integer' do
+      expect(query.limit('20').limit_value).to eq(20)
+    end
+
+    it 'returns self when the limit is less than 0' do
+      expect(query.limit(-1)).to eq(query)
+    end
+
+    it 'returns self when the limit is 0' do
+      expect(query.limit(0)).to eq(query)
+    end
+
+    context 'when definition have [:body][:size] value' do
+      let(:params) do
+        {
+          body: {
+            size: 10
+          }
+        }
+      end
+
+      it 'updates the definition' do
+        expect(query.limit(20).definition).to eq(
+          body: {
+            size: 20
+          }
+        )
+      end
+    end
+
+    context 'when definition have [:body]["size"] value' do
+      let(:params) do
+        {
+          body: {
+            'size' => 10
+          }
+        }
+      end
+
+      it 'updates the definition' do
+        expect(query.limit(20).definition).to eq(
+          body: {
+            'size' => 20
+          }
+        )
+      end
+    end
+
+    context 'when params have the :size' do
+      let(:params) { { size: 20 } }
+
+      it 'updates the definition' do
+        expect(query.limit(10).definition).to eq(
+          size: 10
+        )
+      end
+    end
+
+    context 'when params have the :size and definition have [:body][:size] value' do
+      let(:params) do
+        {
+          size: 30,
+          body: {
+            size: 40
+          }
+        }
+      end
+
+      it 'updates the definition' do
+        expect(query.limit(20).definition).to eq(
+          body: {
+            size: 20
+          }
+        )
+      end
+    end
+  end
+
+  describe '#offset' do
+    let(:query) { described_class.new(Class.new(Esse::Index), **params) }
+    let(:params) { {} }
+
+    it 'returns a new query' do
+      expect { query.offset(20) }.not_to change { query.definition }
+      expect(query.offset(20)).to be_a(described_class)
+    end
+
+    it 'sets the offset value' do
+      expect(query.offset(20).offset_value).to eq(20)
+    end
+
+    it 'sets the offset value as an integer' do
+      expect(query.offset('20').offset_value).to eq(20)
+    end
+
+    it 'returns self when the offset is less than 0' do
+      expect(query.offset(-1)).to eq(query)
+    end
+
+    context 'when definition have [:body][:from] value' do
+      let(:params) do
+        {
+          body: {
+            from: 10
+          }
+        }
+      end
+
+      it 'updates the definition' do
+        expect(query.offset(20).definition).to eq(
+          body: {
+            from: 20
+          }
+        )
+      end
+    end
+
+    context 'when definition have [:body]["from"] value' do
+      let(:params) do
+        {
+          body: {
+            'from' => 10
+          }
+        }
+      end
+
+      it 'updates the definition' do
+        expect(query.offset(20).definition).to eq(
+          body: {
+            'from' => 20
+          }
+        )
+      end
+    end
+
+    context 'when params have the :from' do
+      let(:params) { { from: 20 } }
+
+      it 'updates the definition' do
+        expect(query.offset(10).definition).to eq(
+          from: 10
+        )
+      end
+    end
+
+    context 'when params have the :from and definition have [:body][:from] value' do
+      let(:params) do
+        {
+          from: 30,
+          body: {
+            from: 40
+          }
+        }
+      end
+
+      it 'updates the definition' do
+        expect(query.offset(20).definition).to eq(
+          body: {
+            from: 20
+          }
+        )
+      end
+    end
+  end
+
+  describe '#raw_offset_value' do
+    subject { described_class.new(Class.new(Esse::Index), **params).send(:raw_offset_value) }
+
+    let(:params) { {} }
+
+    it { is_expected.to eq(nil) }
+
+    context 'when definition have [:body][:from] value' do
+      let(:params) do
+        {
+          body: {
+            from: 10
+          }
+        }
+      end
+
+      it { is_expected.to eq(10) }
+    end
+
+    context 'when definition have [:body]["from"] value' do
+      let(:params) do
+        {
+          body: {
+            'from' => 10
+          }
+        }
+      end
+
+      it { is_expected.to eq(10) }
+    end
+
+    context 'when params have the :from' do
+      let(:params) { { from: 20 } }
+
+      it { is_expected.to eq(20) }
+    end
+  end
+end

--- a/spec/esse/search/query_spec.rb
+++ b/spec/esse/search/query_spec.rb
@@ -4,11 +4,29 @@ require 'spec_helper'
 
 RSpec.describe Esse::Search::Query do
   describe '.normalize_indices' do
-    it 'returns an array of index names' do
-      expect(described_class.normalize_indices('events')).to eq(['events'])
-      expect(described_class.normalize_indices('events', 'venues')).to eq(['events', 'venues'])
-      expect(described_class.normalize_indices(EventsIndex)).to eq(['events'])
-      expect(described_class.normalize_indices(EventsIndex, VenuesIndex)).to eq(['events', 'venues'])
+    context 'when the argument is a string' do
+      it 'returns a string with names' do
+        expect(described_class.normalize_indices('events')).to eq('events')
+        expect(described_class.normalize_indices('events', 'venues')).to eq('events,venues')
+      end
+    end
+
+    context 'when the argument is a symbol' do
+      it 'returns a string with names' do
+        expect(described_class.normalize_indices(:events)).to eq('events')
+        expect(described_class.normalize_indices(:events, :venues)).to eq('events,venues')
+      end
+    end
+
+    context 'when the argument is Esse::Index' do
+      before do
+        stub_index(:events)
+        stub_index(:venues)
+      end
+      it 'returns a string with names' do
+        expect(described_class.normalize_indices(EventsIndex)).to eq('events')
+        expect(described_class.normalize_indices(EventsIndex, VenuesIndex)).to eq('events,venues')
+      end
     end
   end
 

--- a/spec/esse/search/query_spec.rb
+++ b/spec/esse/search/query_spec.rb
@@ -3,6 +3,15 @@
 require 'spec_helper'
 
 RSpec.describe Esse::Search::Query do
+  describe '.normalize_indices' do
+    it 'returns an array of index names' do
+      expect(described_class.normalize_indices('events')).to eq(['events'])
+      expect(described_class.normalize_indices('events', 'venues')).to eq(['events', 'venues'])
+      expect(described_class.normalize_indices(EventsIndex)).to eq(['events'])
+      expect(described_class.normalize_indices(EventsIndex, VenuesIndex)).to eq(['events', 'venues'])
+    end
+  end
+
   describe '#definition' do
     before do
       stub_index(:events)

--- a/spec/esse_spec.rb
+++ b/spec/esse_spec.rb
@@ -14,6 +14,15 @@ RSpec.describe Esse do
     it { expect { described_class.config(&:to_s) }.not_to raise_error }
   end
 
+  describe '.cluster' do
+    it { expect(described_class).to respond_to(:cluster) }
+
+    it 'delegates to Esse::Config#cluster' do
+      expect(described_class.config).to receive(:cluster).and_call_original
+      described_class.cluster
+    end
+  end
+
   describe '.timestamp' do
     it { expect(Esse.timestamp).to be_kind_of(String) }
   end


### PR DESCRIPTION
Adding extra search functionality to simplify the use of [esse-pagy](https://github.com/marcosgz/esse-pagy) integration.


* Add `limit` method to the `Esse::Search::Query` class
* Add `offset` method to the `Esse::Search::Query` class
* Add `limit_value` method to the `Esse::Search::Query` class
* Add `offset_value` method to the `Esse::Search::Query` class
* Expose `cluster` method to the `Esse` module as a shortcut to `Esse.config.cluster`
* Add `deep_dup` method to the `Esse::HashUtils` module
* Move pagination and mutation related methods to a new mixin `Esse::Search::Query::DSL`

