### PR TITLE
Tune index settings for better performance during index reset

### DIFF
--- a/lib/esse/index/indices.rb
+++ b/lib/esse/index/indices.rb
@@ -51,13 +51,8 @@ module Esse
       def reset_index(suffix: index_suffix, optimize: true, import: true, reindex: false, **options)
         cluster.throw_error_when_readonly!
 
-        remove_root_in_use_index_named = nil
-        if index_name == index_name(suffix: suffix) && index_exist?(suffix: suffix)
-          remove_root_in_use_index_named = index_name
-          suffix = Esse.timestamp
-        elsif suffix.nil? || index_exist?(suffix: suffix)
-          suffix = Esse.timestamp
-        end
+        suffix ||= Esse.timestamp
+        suffix = Esse.timestamp while index_exist?(suffix: suffix)
 
         if optimize
           definition = [settings_hash, mappings_hash].reduce(&:merge)
@@ -82,8 +77,6 @@ module Esse
         if optimize && number_of_replicas != new_number_of_replicas || refresh_interval != new_refresh_interval
           update_settings(suffix: suffix)
         end
-
-        cluster.api.delete_index(index: remove_root_in_use_index_named) if remove_root_in_use_index_named
 
         update_aliases(suffix: suffix)
 

--- a/spec/esse/cluster_spec.rb
+++ b/spec/esse/cluster_spec.rb
@@ -199,13 +199,15 @@ RSpec.describe Esse::Cluster do
 
     it 'retuns an instance of elasticsearch as default' do
       expect(model.instance_variable_get(:@client)).to eq(nil)
-      if defined? Elasticsearch::Transport::Client
-        expect(model.client).to be_an_instance_of(Elasticsearch::Transport::Client)
-        expect(model.instance_variable_get(:@client)).to be_an_instance_of(Elasticsearch::Transport::Client)
-      else # Elasticsearch-ruby >= 8.0
-        expect(model.client).to be_an_instance_of(Elasticsearch::Client)
-        expect(model.instance_variable_get(:@client)).to be_an_instance_of(Elasticsearch::Client)
+      classes = []
+      if defined? Elasticsearch::Client # Elasticsearch-ruby >= 8.0
+        classes << Elasticsearch::Client
       end
+      if defined? Elasticsearch::Transport::Client
+        classes << Elasticsearch::Transport::Client
+      end
+      expect(classes).to include(model.client.class)
+      expect(model.client).to be(model.instance_variable_get(:@client))
     end
 
     it 'store connection using default key' do


### PR DESCRIPTION
by passing `optimize: true` when reseting the index, system will automatically set the number of replicas to zero and refresh interval to -1. After finish importing data the original value should will be set