### PR TITLE
feat: last retry import each bulk action individually

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,3 +36,6 @@ Style/StringLiterals:
 
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: single_quotes
+
+RSpec/ExampleLength:
+  Max: 20


### PR DESCRIPTION
increase the max retry of bulk import from 3 to 4. And during the last attempt, submit each bulk item individually.