### PR TITLE
Lazy document attribute

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    esse (0.2.6)
+    esse (0.3.0)
       multi_json
       thor (>= 0.19)
 

--- a/bin/console
+++ b/bin/console
@@ -5,8 +5,9 @@ require 'dotenv/load'
 require 'esse'
 require 'pry'
 require 'awesome_print'
+require 'elasticsearch'
 
-Esse.config.clusters.client = { url: ENV.fetch('ESSE_URL', ENV.fetch('ELASTICSEARCH_URL', 'http://localhost:9200')) }
+Esse.config.clusters.client = Elasticsearch::Client.new url: ENV.fetch('ESSE_URL', ENV.fetch('ELASTICSEARCH_URL', 'http://localhost:9200'))
 Esse.config.clusters.index_prefix = 'esse_console'
 
 US_STATES = {
@@ -64,7 +65,7 @@ class GeosIndex < ApplicationIndex
           autocomplete: {
             type: 'custom',
             tokenizer: 'standard',
-            filter: %w[lowercase asciifolding]
+            filter: %w[lowercase asciifolding]\
           },
         },
       }
@@ -99,6 +100,7 @@ class GeosIndex < ApplicationIndex
 
     document do |(state, name), **|
       {
+        _id: state.downcase,
         name: name,
         routing: state,
       }
@@ -114,7 +116,7 @@ class GeosIndex < ApplicationIndex
 
     document do |(abbr, name), **|
       {
-        id: abbr,
+        _id: abbr,
         name: name,
         routing: abbr,
       }

--- a/gemfiles/Gemfile.elasticsearch-1.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-1.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.2.6)
+    esse (0.3.0)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-2.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-2.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.2.6)
+    esse (0.3.0)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-5.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-5.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.2.6)
+    esse (0.3.0)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-6.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-6.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.2.6)
+    esse (0.3.0)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-7.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-7.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.2.6)
+    esse (0.3.0)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-8.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-8.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.2.6)
+    esse (0.3.0)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.opensearch-1.x.lock
+++ b/gemfiles/Gemfile.opensearch-1.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.2.6)
+    esse (0.3.0)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.opensearch-2.x.lock
+++ b/gemfiles/Gemfile.opensearch-2.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.2.6)
+    esse (0.3.0)
       multi_json
       thor (>= 0.19)
 

--- a/lib/esse/cli/index.rb
+++ b/lib/esse/cli/index.rb
@@ -88,9 +88,20 @@ module Esse
       option :suffix, type: :string, default: nil, aliases: '-s', desc: 'Suffix to append to index name'
       option :context, type: :hash, default: {}, required: true, desc: 'List of options to pass to the index class'
       option :repo, type: :string, default: nil, alias: '-r', desc: 'Repository to use for import'
+      option :eager_include_document_attributes, type: :string, default: nil, desc: 'Comma separated list of lazy document attributes to include to the bulk index request'
+      option :lazy_update_document_attributes, type: :string, default: nil, desc: 'Comma separated list of lazy document attributes to bulk update after the bulk index request'
       def import(*index_classes)
         require_relative 'index/import'
-        Import.new(indices: index_classes, **HashUtils.deep_transform_keys(options.to_h, &:to_sym)).run
+        opts = HashUtils.deep_transform_keys(options.to_h, &:to_sym)
+        opts.delete(:lazy_update_document_attributes) if opts[:lazy_update_document_attributes] == 'false'
+        opts.delete(:eager_include_document_attributes) if opts[:eager_include_document_attributes] == 'false'
+        if (val = opts[:eager_include_document_attributes])
+          opts[:eager_include_document_attributes] = (val == 'true') ? true : val.split(',')
+        end
+        if (val = opts[:lazy_update_document_attributes])
+          opts[:lazy_update_document_attributes] = (val == 'true') ? true : val.split(',')
+        end
+        Import.new(indices: index_classes, **opts).run
       end
     end
   end

--- a/lib/esse/core.rb
+++ b/lib/esse/core.rb
@@ -7,6 +7,7 @@ module Esse
   require_relative 'collection'
   require_relative 'document'
   require_relative 'document_lazy_attribute'
+  require_relative 'lazy_document_header'
   require_relative 'hash_document'
   require_relative 'null_document'
   require_relative 'repository'

--- a/lib/esse/core.rb
+++ b/lib/esse/core.rb
@@ -6,6 +6,7 @@ module Esse
   require_relative 'primitives'
   require_relative 'collection'
   require_relative 'document'
+  require_relative 'document_lazy_attribute'
   require_relative 'hash_document'
   require_relative 'null_document'
   require_relative 'repository'

--- a/lib/esse/document.rb
+++ b/lib/esse/document.rb
@@ -66,10 +66,8 @@ module Esse
     end
 
     def to_bulk(data: true)
-      { _id: id }.tap do |h|
-        h[:data] = source&.to_h if data
-        h[:_type] = type if type
-        h[:routing] = routing if routing?
+      doc_header.tap do |h|
+        h[:data] = source if data
         h.merge!(meta)
       end
     end
@@ -86,6 +84,13 @@ module Esse
       other.is_a?(self.class) && (
         id == other.id && type == other.type && routing == other.routing && meta == other.meta && source == other.source
       )
+    end
+
+    def doc_header
+      { _id: id }.tap do |h|
+        h[:_type] = type if type
+        h[:_routing] = routing if routing?
+      end
     end
   end
 end

--- a/lib/esse/document.rb
+++ b/lib/esse/document.rb
@@ -65,9 +65,13 @@ module Esse
       end
     end
 
-    def to_bulk(data: true)
+    def to_bulk(data: true, operation: nil)
       doc_header.tap do |h|
-        h[:data] = source if data
+        if data && operation == :update
+          h[:data] = { doc: source }
+        elsif data
+          h[:data] = source
+        end
         h.merge!(meta)
       end
     end

--- a/lib/esse/document_lazy_attribute.rb
+++ b/lib/esse/document_lazy_attribute.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Esse
+  class DocumentLazyAttribute
+    # Returns an Hash with the document ID as key and attribute data as value.
+    def call(document_ids)
+      raise NotImplementedError, 'Override this method to return the document attribute data'
+    end
+  end
+end

--- a/lib/esse/document_lazy_attribute.rb
+++ b/lib/esse/document_lazy_attribute.rb
@@ -2,8 +2,15 @@
 
 module Esse
   class DocumentLazyAttribute
+    attr_reader :options
+
+    def initialize(**kwargs)
+      @options = kwargs
+    end
+
     # Returns an Hash with the document ID as key and attribute data as value.
     # @param doc_headers [Array<Esse::LazyDocumentHeader>] the document headers
+    # @return [Hash] An Hash with the instance of document header as key and the attribute data as value.
     def call(doc_headers)
       raise NotImplementedError, 'Override this method to return the document attribute data'
     end

--- a/lib/esse/document_lazy_attribute.rb
+++ b/lib/esse/document_lazy_attribute.rb
@@ -3,7 +3,8 @@
 module Esse
   class DocumentLazyAttribute
     # Returns an Hash with the document ID as key and attribute data as value.
-    def call(document_ids)
+    # @param doc_headers [Array<Esse::LazyDocumentHeader>] the document headers
+    def call(doc_headers)
       raise NotImplementedError, 'Override this method to return the document attribute data'
     end
   end

--- a/lib/esse/import/bulk.rb
+++ b/lib/esse/import/bulk.rb
@@ -13,7 +13,7 @@ module Esse
           { create: value }
         end
         @update = Array(update).select(&method(:valid_doc?)).reject(&:ignore_on_index?).map do |doc|
-          value = doc.to_bulk
+          value = doc.to_bulk(operation: :update)
           value[:_type] ||= type if type
           { update: value }
         end

--- a/lib/esse/import/bulk.rb
+++ b/lib/esse/import/bulk.rb
@@ -1,7 +1,7 @@
 module Esse
   module Import
     class Bulk
-      def initialize(type: nil, index: nil, delete: nil, create: nil)
+      def initialize(type: nil, index: nil, delete: nil, create: nil, update: nil)
         @index = Array(index).select(&method(:valid_doc?)).reject(&:ignore_on_index?).map do |doc|
           value = doc.to_bulk
           value[:_type] ||= type if type
@@ -11,6 +11,11 @@ module Esse
           value = doc.to_bulk
           value[:_type] ||= type if type
           { create: value }
+        end
+        @update = Array(update).select(&method(:valid_doc?)).reject(&:ignore_on_index?).map do |doc|
+          value = doc.to_bulk
+          value[:_type] ||= type if type
+          { update: value }
         end
         @delete = Array(delete).select(&method(:valid_doc?)).reject(&:ignore_on_delete?).map do |doc|
           value = doc.to_bulk(data: false)
@@ -69,17 +74,19 @@ module Esse
 
       def optimistic_request
         request = Import::RequestBodyAsJson.new
-        request.delete = @delete
         request.create = @create
         request.index = @index
+        request.update = @update
+        request.delete = @delete
         request
       end
 
       def requests_in_small_chunks(chunk_size: 1)
         arr = []
-        @delete.each_slice(chunk_size) { |slice| arr << Import::RequestBodyAsJson.new.tap { |r| r.delete = slice } }
         @create.each_slice(chunk_size) { |slice| arr << Import::RequestBodyAsJson.new.tap { |r| r.create = slice } }
         @index.each_slice(chunk_size) { |slice| arr << Import::RequestBodyAsJson.new.tap { |r| r.index = slice } }
+        @update.each_slice(chunk_size) { |slice| arr << Import::RequestBodyAsJson.new.tap { |r| r.update = slice } }
+        @delete.each_slice(chunk_size) { |slice| arr << Import::RequestBodyAsJson.new.tap { |r| r.delete = slice } }
         Esse.logger.warn <<~MSG
           Retrying the last request in small chunks of #{chunk_size} documents.
           This is a last resort to avoid timeout errors, consider increasing the bulk size or reducing the batch size.
@@ -90,7 +97,7 @@ module Esse
       # @return [Array<RequestBody>]
       def balance_requests_size(err)
         if (bulk_size = err.message.scan(/exceeded.(\d+).bytes/).dig(0, 0).to_i) > 0
-          requests = (@delete + @create + @index).each_with_object([Import::RequestBodyRaw.new]) do |as_json, result|
+          requests = (@create + @index + @update + @delete).each_with_object([Import::RequestBodyRaw.new]) do |as_json, result|
             operation, meta = as_json.to_a.first
             meta = meta.dup
             data = meta.delete(:data)

--- a/lib/esse/import/request_body.rb
+++ b/lib/esse/import/request_body.rb
@@ -5,7 +5,7 @@ module Esse
 
       def initialize(body:)
         @body = body # body may be String or Array<Hash>
-        @stats = { index: 0, create: 0, delete: 0 }
+        @stats = { index: 0, create: 0, delete: 0, update: 0 }
       end
 
       def body?
@@ -44,6 +44,11 @@ module Esse
       def index=(docs)
         @body += docs
         @stats[:index] += docs.size
+      end
+
+      def update=(docs)
+        @body += docs
+        @stats[:update] += docs.size
       end
 
       def create=(docs)

--- a/lib/esse/index/documents.rb
+++ b/lib/esse/index/documents.rb
@@ -164,7 +164,7 @@ module Esse
       # @see https://www.elastic.co/guide/en/elasticsearch/reference/7.5/docs-bulk.html
       # @see https://github.com/elastic/elasticsearch-ruby/blob/main/elasticsearch-api/lib/elasticsearch/api/utils.rb
       # @see https://github.com/elastic/elasticsearch-ruby/blob/main/elasticsearch-api/lib/elasticsearch/api/actions/bulk.rb
-      def bulk(index: nil, delete: nil, create: nil, type: nil, suffix: nil, **options)
+      def bulk(create: nil, delete: nil, index: nil, update: nil, type: nil, suffix: nil, **options)
         definition = {
           index: index_name(suffix: suffix),
           type: type,
@@ -174,9 +174,10 @@ module Esse
         # @TODO Wrap the return in a some other Stats object with more information
         Esse::Import::Bulk.new(
           **definition.slice(:type),
-          index: index,
-          delete: delete,
           create: create,
+          delete: delete,
+          index: index,
+          update: update,
         ).each_request do |request_body|
           cluster.api.bulk(**definition, body: request_body.body) do |event_payload|
             event_payload[:body_stats] = request_body.stats

--- a/lib/esse/index/documents.rb
+++ b/lib/esse/index/documents.rb
@@ -210,9 +210,12 @@ module Esse
             #
             # Note that the repository name will be used as the document type.
             # mapping_default_type
-            kwargs = { index: batch, suffix: suffix, type: repo_name, **options }
+            kwargs = { suffix: suffix, type: repo_name, **options }
             cluster.may_update_type!(kwargs)
-            bulk(**kwargs)
+            bulk(**kwargs, index: batch)
+            # repo.bulk_update_data_for_lazy_attributes(batch) do |data|
+            #   bulk(**kwargs, update: data)
+            # end
             count += batch.size
           end
         end

--- a/lib/esse/lazy_document_header.rb
+++ b/lib/esse/lazy_document_header.rb
@@ -60,5 +60,14 @@ module Esse
     def routing
       @attributes[:_routing]
     end
+
+    def to_doc(source = {})
+      HashDocument.new(source.merge(@attributes))
+    end
+
+    def eql?(other)
+      self.class == other.class && @attributes == other.instance_variable_get(:@attributes)
+    end
+    alias_method :==, :eql?
   end
 end

--- a/lib/esse/lazy_document_header.rb
+++ b/lib/esse/lazy_document_header.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Esse
+  class LazyDocumentHeader
+    def self.coerce_each(values)
+      arr = []
+      Array(values).map do |value|
+        instance = coerce(value)
+        arr << instance if instance&.valid?
+      end
+      arr
+    end
+
+    def self.coerce(value)
+      return unless value
+
+      if value.is_a?(Esse::LazyDocumentHeader)
+        value
+      elsif value.is_a?(Esse::Document)
+        new(value.doc_header)
+      elsif value.is_a?(Hash)
+        resp = value.transform_keys do |key|
+          case key
+          when :_id, :id, '_id', 'id'
+            :_id
+          when :_routing, :routing, '_routing', 'routing'
+            :_routing
+          when :_type, :type, '_type', 'type'
+            :_type
+          else
+            key.to_sym
+          end
+        end
+        new(resp)
+      elsif String === value || Integer === value
+        new(_id: value)
+      end
+    end
+
+    def initialize(attributes)
+      @attributes = attributes
+    end
+
+    def valid?
+      !@attributes[:_id].nil?
+    end
+
+    def to_h
+      @attributes
+    end
+
+    def id
+      @attributes.fetch(:_id)
+    end
+
+    def type
+      @attributes[:_type]
+    end
+
+    def routing
+      @attributes[:_routing]
+    end
+  end
+end

--- a/lib/esse/repository.rb
+++ b/lib/esse/repository.rb
@@ -13,5 +13,6 @@ module Esse
     require_relative 'repository/actions'
     require_relative 'repository/documents'
     require_relative 'repository/object_document_mapper'
+    require_relative 'repository/lazy_document_attributes'
   end
 end

--- a/lib/esse/repository/documents.rb
+++ b/lib/esse/repository/documents.rb
@@ -6,6 +6,38 @@ module Esse
       def import(**kwargs)
         index.import(repo_name, **kwargs)
       end
+
+      def update_documents_attribute(name, *ids_or_doc_headers, **kwargs)
+        batch = documents_for_lazy_attribute(name, *ids_or_doc_headers)
+        return if batch.empty?
+
+        index.bulk(**kwargs, update: batch)
+      end
+
+      def documents_for_lazy_attribute(name, *ids_or_doc_headers)
+        unless lazy_document_attribute?(name)
+          raise ArgumentError, <<~MSG
+            The attribute `#{name}` is not defined as a lazy document attribute.
+
+            Define the attribute as a lazy document attribute using the `lazy_document_attribute` method.
+          MSG
+        end
+
+        docs = LazyDocumentHeader.coerce_each(ids_or_doc_headers)
+        return [] if docs.empty?
+
+        arr = []
+        result = fetch_lazy_document_attribute(name).call(docs)
+        return [] unless result.is_a?(Hash)
+
+        result.each do |key, datum|
+          doc = docs.find { |d| d == key || d.id == key }
+          next unless doc
+
+          arr << doc.to_doc(name => datum)
+        end
+        arr
+      end
     end
 
     extend ClassMethods

--- a/lib/esse/repository/lazy_document_attributes.rb
+++ b/lib/esse/repository/lazy_document_attributes.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Esse
+  # Definition for the lazy document attributes
+  class Repository
+    module ClassMethods
+      def lazy_document_attributes
+        @lazy_document_attributes ||= {}.freeze
+      end
+
+      def lazy_document_attribute?(attr_name)
+        lazy_document_attributes.key?(attr_name.to_s)
+      end
+
+      def fetch_lazy_document_attribute(attr_name)
+        klass, kwargs = lazy_document_attributes.fetch(attr_name.to_s)
+        klass.new(**kwargs)
+      rescue KeyError
+        raise ArgumentError, format('Attribute %<attr>p is not defined as a lazy document attribute', attr: attr_name)
+      end
+
+      def lazy_document_attribute(attr_name, klass = nil, **kwargs, &block)
+        if lazy_document_attribute?(attr_name)
+          raise ArgumentError, format('Attribute %<attr>p is already defined as a lazy document attribute', attr: attr_name)
+        end
+
+        @lazy_document_attributes = lazy_document_attributes.dup
+        if block
+          klass = Class.new(Esse::DocumentLazyAttribute) do
+            define_method(:call, &block)
+          end
+          @lazy_document_attributes[attr_name.to_s] = [klass, kwargs]
+        elsif klass.is_a?(Class) && klass <= Esse::DocumentLazyAttribute
+          @lazy_document_attributes[attr_name.to_s] = [klass, kwargs]
+        elsif klass.is_a?(Class) && klass.instance_methods.include?(:call)
+          @lazy_document_attributes[attr_name.to_s] = [klass, kwargs]
+        elsif klass.nil?
+          raise ArgumentError, format('A block or a class that responds to `call` is required to define a lazy document attribute')
+        else
+          raise ArgumentError, format('%<arg>p is not a valid lazy document attribute. Class should inherit from Esse::DocumentLazyAttribute or respond to `call`', arg: klass)
+        end
+      ensure
+        @lazy_document_attributes&.freeze
+      end
+    end
+
+    extend ClassMethods
+  end
+end

--- a/lib/esse/repository/object_document_mapper.rb
+++ b/lib/esse/repository/object_document_mapper.rb
@@ -168,20 +168,11 @@ module Esse
         if block
           klass = Class.new(Esse::DocumentLazyAttribute)
           klass.define_singleton_method(:call, &block)
-          @lazy_document_attributes[attr_name.to_s] = ->(arr) do
-            headers = Esse::LazyDocumentHeader.coerce_each(arr)
-            klass.new(**kwargs).call(headers) if headers.any?
-          end
+          @lazy_document_attributes[attr_name.to_s] = [klass, kwargs]
         elsif klass.is_a?(Class) && klass <= Esse::DocumentLazyAttribute
-          @lazy_document_attributes[attr_name.to_s] = ->(arr) do
-            headers = Esse::LazyDocumentHeader.coerce_each(arr)
-            klass.new(**kwargs).call(headers) if headers.any?
-          end
+          @lazy_document_attributes[attr_name.to_s] = [klass, kwargs]
         elsif klass.is_a?(Class) && klass.instance_methods.include?(:call)
-          @lazy_document_attributes[attr_name.to_s] = ->(arr) do
-            headers = Esse::LazyDocumentHeader.coerce_each(arr)
-            klass.new(**kwargs).call(headers) if headers.any?
-          end
+          @lazy_document_attributes[attr_name.to_s] = [klass, kwargs]
         elsif klass.nil?
           raise ArgumentError, format('A block or a class that responds to `call` is required to define a lazy document attribute')
         else

--- a/lib/esse/repository/object_document_mapper.rb
+++ b/lib/esse/repository/object_document_mapper.rb
@@ -150,45 +150,6 @@ module Esse
           end
         end
       end
-
-      def lazy_document_attributes
-        @lazy_document_attributes ||= {}.freeze
-      end
-
-      def lazy_document_attribute?(attr_name)
-        lazy_document_attributes.key?(attr_name.to_s)
-      end
-
-      def fetch_lazy_document_attribute(attr_name)
-        klass, kwargs = lazy_document_attributes.fetch(attr_name.to_s)
-        klass.new(**kwargs)
-      rescue KeyError
-        raise ArgumentError, format('Attribute %<attr>p is not defined as a lazy document attribute', attr: attr_name)
-      end
-
-      def lazy_document_attribute(attr_name, klass = nil, **kwargs, &block)
-        if lazy_document_attribute?(attr_name)
-          raise ArgumentError, format('Attribute %<attr>p is already defined as a lazy document attribute', attr: attr_name)
-        end
-
-        @lazy_document_attributes = lazy_document_attributes.dup
-        if block
-          klass = Class.new(Esse::DocumentLazyAttribute) do
-            define_method(:call, &block)
-          end
-          @lazy_document_attributes[attr_name.to_s] = [klass, kwargs]
-        elsif klass.is_a?(Class) && klass <= Esse::DocumentLazyAttribute
-          @lazy_document_attributes[attr_name.to_s] = [klass, kwargs]
-        elsif klass.is_a?(Class) && klass.instance_methods.include?(:call)
-          @lazy_document_attributes[attr_name.to_s] = [klass, kwargs]
-        elsif klass.nil?
-          raise ArgumentError, format('A block or a class that responds to `call` is required to define a lazy document attribute')
-        else
-          raise ArgumentError, format('%<arg>p is not a valid lazy document attribute. Class should inherit from Esse::DocumentLazyAttribute or respond to `call`', arg: klass)
-        end
-      ensure
-        @lazy_document_attributes&.freeze
-      end
     end
 
     extend ClassMethods

--- a/lib/esse/repository/object_document_mapper.rb
+++ b/lib/esse/repository/object_document_mapper.rb
@@ -159,6 +159,13 @@ module Esse
         lazy_document_attributes.key?(attr_name.to_s)
       end
 
+      def fetch_lazy_document_attribute(attr_name)
+        klass, kwargs = lazy_document_attributes.fetch(attr_name.to_s)
+        klass.new(**kwargs)
+      rescue KeyError
+        raise ArgumentError, format('Attribute %<attr>p is not defined as a lazy document attribute', attr: attr_name)
+      end
+
       def lazy_document_attribute(attr_name, klass = nil, **kwargs, &block)
         if lazy_document_attribute?(attr_name)
           raise ArgumentError, format('Attribute %<attr>p is already defined as a lazy document attribute', attr: attr_name)
@@ -166,8 +173,9 @@ module Esse
 
         @lazy_document_attributes = lazy_document_attributes.dup
         if block
-          klass = Class.new(Esse::DocumentLazyAttribute)
-          klass.define_singleton_method(:call, &block)
+          klass = Class.new(Esse::DocumentLazyAttribute) do
+            define_method(:call, &block)
+          end
           @lazy_document_attributes[attr_name.to_s] = [klass, kwargs]
         elsif klass.is_a?(Class) && klass <= Esse::DocumentLazyAttribute
           @lazy_document_attributes[attr_name.to_s] = [klass, kwargs]

--- a/lib/esse/repository/object_document_mapper.rb
+++ b/lib/esse/repository/object_document_mapper.rb
@@ -128,12 +128,12 @@ module Esse
       # @param [Hash] kwargs The context
       # @return [Enumerator] The enumerator
       # @yield [Array, **context] serialized collection and the optional context from the collection
-      def each_serialized_batch(**kwargs, &block)
+      def each_serialized_batch(**kwargs)
         each_batch(**kwargs) do |*args|
           batch, collection_context = args
           collection_context ||= {}
           entries = [*batch].map { |entry| serialize(entry, **collection_context) }.compact
-          block.call(entries, **kwargs)
+          yield entries, **kwargs
         end
       end
 

--- a/lib/esse/version.rb
+++ b/lib/esse/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Esse
-  VERSION = '0.2.6'
+  VERSION = '0.3.0'
 end

--- a/spec/esse/cli/index/import_spec.rb
+++ b/spec/esse/cli/index/import_spec.rb
@@ -57,6 +57,46 @@ RSpec.describe Esse::CLI::Index, type: :cli do
         expect(CitiesIndex).to receive(:import).and_return(true)
         cli_exec(%w[index import CountiesIndex CitiesIndex])
       end
+
+      it 'allows --eager-include-document-attributes as a comma separated list' do
+        expect(CountiesIndex).to receive(:import).with(eager_include_document_attributes: %w[foo bar], context: {}).and_return(true)
+        cli_exec(%w[index import CountiesIndex --eager-include-document-attributes=foo,bar])
+      end
+
+      it 'allows --lazy-update-document-attributes as a single value' do
+        expect(CountiesIndex).to receive(:import).with(lazy_update_document_attributes: %w[foo], context: {}).and_return(true)
+        cli_exec(%w[index import CountiesIndex --lazy-update-document-attributes=foo])
+      end
+
+      it 'allows --lazy-update-document-attributes as true' do
+        expect(CountiesIndex).to receive(:import).with(lazy_update_document_attributes: true, context: {}).and_return(true)
+        cli_exec(%w[index import CountiesIndex --lazy-update-document-attributes=true])
+      end
+
+      it 'allows --lazy-update-document-attributes as false' do
+        expect(CountiesIndex).to receive(:import).with(context: {}).and_return(true)
+        cli_exec(%w[index import CountiesIndex --lazy-update-document-attributes=false])
+      end
+
+      it 'allows --lazy-update-document-attributes as a comma separated list' do
+        expect(CountiesIndex).to receive(:import).with(lazy_update_document_attributes: %w[foo bar], context: {}).and_return(true)
+        cli_exec(%w[index import CountiesIndex --lazy-update-document-attributes=foo,bar])
+      end
+
+      it 'allows --lazy-update-document-attributes as a single value' do
+        expect(CountiesIndex).to receive(:import).with(lazy_update_document_attributes: %w[foo], context: {}).and_return(true)
+        cli_exec(%w[index import CountiesIndex --lazy-update-document-attributes=foo])
+      end
+
+      it 'allows --lazy-update-document-attributes as true' do
+        expect(CountiesIndex).to receive(:import).with(lazy_update_document_attributes: true, context: {}).and_return(true)
+        cli_exec(%w[index import CountiesIndex --lazy-update-document-attributes=true])
+      end
+
+      it 'allows --lazy-update-document-attributes as false' do
+        expect(CountiesIndex).to receive(:import).with(context: {}).and_return(true)
+        cli_exec(%w[index import CountiesIndex --lazy-update-document-attributes=false])
+      end
     end
   end
 end

--- a/spec/esse/document_spec.rb
+++ b/spec/esse/document_spec.rb
@@ -91,13 +91,13 @@ RSpec.describe Esse::Document do
     context 'with data: true' do
       subject { document.to_bulk(data: true) }
 
-      it { is_expected.to eq(_id: 1, _type: 'foo', routing: 'bar', timeout: 10, data: { foo: 'bar' }) }
+      it { is_expected.to eq(_id: 1, _type: 'foo', _routing: 'bar', timeout: 10, data: { foo: 'bar' }) }
     end
 
     context 'with data: false' do
       subject { document.to_bulk(data: false) }
 
-      it { is_expected.to eq(_id: 1, _type: 'foo', routing: 'bar', timeout: 10) }
+      it { is_expected.to eq(_id: 1, _type: 'foo', _routing: 'bar', timeout: 10) }
     end
 
     context 'when document does not have a routing' do
@@ -110,21 +110,59 @@ RSpec.describe Esse::Document do
     context 'when document does not have a type' do
       it 'should not include the type' do
         allow(document).to receive(:type).and_return(nil)
-        expect(document.to_bulk(data: true)).to eq(_id: 1, routing: 'bar', timeout: 10, data: { foo: 'bar' })
+        expect(document.to_bulk(data: true)).to eq(_id: 1, _routing: 'bar', timeout: 10, data: { foo: 'bar' })
       end
     end
 
     context 'when document does not have a meta' do
       it 'should not include the meta' do
         allow(document).to receive(:meta).and_return({})
-        expect(document.to_bulk(data: true)).to eq(_id: 1, _type: 'foo', routing: 'bar', data: { foo: 'bar' })
+        expect(document.to_bulk(data: true)).to eq(_id: 1, _type: 'foo', _routing: 'bar', data: { foo: 'bar' })
       end
     end
 
     context 'when document does not have a source' do
       it 'should not include the source' do
         allow(document).to receive(:source).and_return({})
-        expect(document.to_bulk(data: true)).to eq(_id: 1, _type: 'foo', routing: 'bar', timeout: 10, data: {})
+        expect(document.to_bulk(data: true)).to eq(_id: 1, _type: 'foo', _routing: 'bar', timeout: 10, data: {})
+      end
+    end
+  end
+
+  describe '#doc_header' do
+    let(:document_class) do
+      Class.new(described_class) do
+        def id
+          1
+        end
+
+        def type
+          'foo'
+        end
+
+        def routing
+          'bar'
+        end
+      end
+    end
+
+    let(:document) { document_class.new(object, **options) }
+
+    subject { document.doc_header }
+
+    it { is_expected.to eq(_id: 1, _type: 'foo', _routing: 'bar') }
+
+    context 'when document does not have a routing' do
+      it 'should not include the routing' do
+        allow(document).to receive(:routing).and_return(nil)
+        expect(document.doc_header).to eq(_id: 1, _type: 'foo')
+      end
+    end
+
+    context 'when document does not have a type' do
+      it 'should not include the type' do
+        allow(document).to receive(:type).and_return(nil)
+        expect(document.doc_header).to eq(_id: 1, _routing: 'bar')
       end
     end
   end

--- a/spec/esse/document_spec.rb
+++ b/spec/esse/document_spec.rb
@@ -100,6 +100,12 @@ RSpec.describe Esse::Document do
       it { is_expected.to eq(_id: 1, _type: 'foo', _routing: 'bar', timeout: 10) }
     end
 
+    context 'with operation: :update' do
+      subject { document.to_bulk(data: true, operation: :update) }
+
+      it { is_expected.to eq(_id: 1, _type: 'foo', _routing: 'bar', timeout: 10, data: { doc: { foo: 'bar' } }) }
+    end
+
     context 'when document does not have a routing' do
       it 'should not include the routing' do
         allow(document).to receive(:routing).and_return(nil)

--- a/spec/esse/lazzy_document_header_spec.rb
+++ b/spec/esse/lazzy_document_header_spec.rb
@@ -170,4 +170,20 @@ RSpec.describe Esse::LazyDocumentHeader do
       expect(described_class.coerce_each([nil, {_id: 1}, {}]).size).to eq(1)
     end
   end
+
+  describe '#to_doc' do
+    it { expect(doc).to respond_to :to_doc }
+
+    it 'returns a HashDocument instance' do
+      expect(doc.to_doc).to be_a(Esse::HashDocument)
+    end
+
+    it 'returns a HashDocument instance with the object as source' do
+      expect(doc.to_doc.source).to eq(object)
+    end
+
+    it 'returns a HashDocument instance with the object as source and the given source' do
+      expect(doc.to_doc(foo: 'bar').source).to eq(object.merge(foo: 'bar'))
+    end
+  end
 end

--- a/spec/esse/lazzy_document_header_spec.rb
+++ b/spec/esse/lazzy_document_header_spec.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Esse::LazyDocumentHeader do
+  let(:doc) { described_class.new(object) }
+  let(:object) { {} }
+  let(:options) { {} }
+
+  describe '#valid?' do
+    it { expect(doc).to respond_to :valid? }
+
+    it 'returns false' do
+      expect(doc.valid?).to be_falsey
+    end
+
+    context 'when _id is present' do
+      let(:object) { { _id: 1 } }
+
+      it 'returns true' do
+        expect(doc.valid?).to be_truthy
+      end
+    end
+  end
+
+  describe '#id' do
+    it { expect(doc).to respond_to :id }
+
+    it 'should raise KeyError' do
+      expect { doc.id }.to raise_error
+    end
+
+    context 'when _id is present' do
+      let(:object) { { _id: 1 } }
+
+      it 'returns the _id' do
+        expect(doc.id).to eq(1)
+      end
+    end
+  end
+
+  describe '#type' do
+    it { expect(doc).to respond_to :type }
+
+    it 'returns nil' do
+      expect(doc.type).to be_nil
+    end
+
+    context 'when _type is present' do
+      let(:object) { { _type: 'foo' } }
+
+      it 'returns the _type' do
+        expect(doc.type).to eq('foo')
+      end
+    end
+  end
+
+  describe '#routing' do
+    it { expect(doc).to respond_to :routing }
+
+    it 'returns nil' do
+      expect(doc.routing).to be_nil
+    end
+
+    context 'when _routing is present' do
+      let(:object) { { _routing: 'foo' } }
+
+      it 'returns the _routing' do
+        expect(doc.routing).to eq('foo')
+      end
+    end
+  end
+
+  describe '#to_h' do
+    it { expect(doc).to respond_to :to_h }
+
+    it 'returns the object' do
+      expect(doc.to_h).to eq(object)
+    end
+
+    context 'when _id is present' do
+      let(:object) { { _id: 1 } }
+
+      it 'returns the object' do
+        expect(doc.to_h).to eq(object)
+      end
+    end
+
+    context 'when _type is present' do
+      let(:object) { { _type: 'foo' } }
+
+      it 'returns the object' do
+        expect(doc.to_h).to eq(object)
+      end
+    end
+
+    context 'when _routing is present' do
+      let(:object) { { _routing: 'foo' } }
+
+      it 'returns the object' do
+        expect(doc.to_h).to eq(object)
+      end
+    end
+  end
+
+  describe '.coerce' do
+    it { expect(described_class).to respond_to :coerce }
+
+    it 'returns nil' do
+      expect(described_class.coerce(nil)).to be_nil
+    end
+
+    context 'when value is a LazyDocumentHeader' do
+      let(:object) { described_class.new(_id: 1) }
+
+      it 'returns the same instance' do
+        expect(described_class.coerce(object)).to eq(object)
+      end
+    end
+
+    context 'when value is a Esse::Document' do
+      let(:object) { Esse::HashDocument.new(_id: 1) }
+
+      it 'returns a LazyDocumentHeader instance' do
+        expect(described_class.coerce(object)).to be_a(described_class)
+      end
+    end
+
+    context 'when value is a Hash' do
+      let(:object) { { _id: 1 } }
+
+      it 'returns a LazyDocumentHeader instance' do
+        expect(described_class.coerce(object)).to be_a(described_class)
+      end
+    end
+
+    context 'when value is a String' do
+      let(:object) { '1' }
+
+      it 'returns a LazyDocumentHeader instance' do
+        expect(described_class.coerce(object)).to be_a(described_class)
+      end
+    end
+
+    context 'when value is a Integer' do
+      let(:object) { 1 }
+
+      it 'returns a LazyDocumentHeader instance' do
+        expect(described_class.coerce(object)).to be_a(described_class)
+      end
+    end
+  end
+
+  describe '.coerce_each' do
+    it { expect(described_class).to respond_to :coerce_each }
+
+    it 'returns an empty array when the give argument is a nil object' do
+      expect(described_class.coerce_each(nil)).to eq([])
+    end
+
+    it 'returns an empty array when the given argument is an empty array' do
+      expect(described_class.coerce_each([])).to eq([])
+    end
+
+    it 'returns an array with a LazyDocumentHeader instance' do
+      expect(described_class.coerce_each([{_id: 1}])).to all(be_a(described_class))
+    end
+
+    it 'removes invalid instances' do
+      expect(described_class.coerce_each([nil, {_id: 1}, {}]).size).to eq(1)
+    end
+  end
+end

--- a/spec/esse/repository/document_spec.rb
+++ b/spec/esse/repository/document_spec.rb
@@ -513,4 +513,22 @@ RSpec.describe Esse::Repository do
       end
     end
   end
+
+  describe '.fetch_lazy_document_attribute' do
+    let(:repo) do
+      Class.new(Esse::Repository) do
+        lazy_document_attribute(:foo) { 'bar' }
+      end
+    end
+
+    it 'returns a lazy attribute' do
+      expect(repo.fetch_lazy_document_attribute(:foo)).to be_a_kind_of(Esse::DocumentLazyAttribute)
+    end
+
+    it 'raises an error when the attribute is not defined' do
+      expect {
+        repo.fetch_lazy_document_attribute(:bar)
+      }.to raise_error(ArgumentError, 'Attribute :bar is not defined as a lazy document attribute')
+    end
+  end
 end

--- a/spec/esse/repository/lazy_document_spec.rb
+++ b/spec/esse/repository/lazy_document_spec.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Esse::Repository do
+  describe '.documents_for_lazy_attribute' do
+    context 'when the attribute is not defined' do
+      let(:repo) { Class.new(Esse::Repository) }
+
+      it 'raises an error' do
+        expect { repo.documents_for_lazy_attribute(:foo) }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'when the attribute is defined and its result is not a hash' do
+      let(:repo) do
+        Class.new(Esse::Repository) do
+          lazy_document_attribute :city_names do |_|
+            Object.new
+          end
+        end
+      end
+
+      it 'returns an empty array when no ids are provided' do
+        expect(repo.documents_for_lazy_attribute(:city_names)).to eq([])
+      end
+
+      it 'returns an empty array when no ids are found' do
+        expect(repo.documents_for_lazy_attribute(:city_names, '3')).to eq([])
+      end
+    end
+
+    context 'when the attribute is defined and its result is hash with id as key' do
+      let(:repo) do
+        Class.new(Esse::Repository) do
+          lazy_document_attribute :city_names do |docs|
+            {
+              '1' => 'Moscow',
+              '2' => 'London',
+            }
+          end
+        end
+      end
+
+      it 'returns an empty array when no ids are provided' do
+        expect(repo.documents_for_lazy_attribute(:city_names)).to eq([])
+      end
+
+      it 'returns an empty array when no ids are found' do
+        expect(repo.documents_for_lazy_attribute(:city_names, '3')).to eq([])
+      end
+
+      it 'returns an array of documents that match with the provided ids' do
+        docs = repo.documents_for_lazy_attribute(:city_names, '2')
+        expect(docs).to eq([
+          Esse::HashDocument.new(_id: '2', city_names: 'London')
+        ])
+      end
+
+      it 'returns an array of documents that match with the provided LazyDocumentHeader' do
+        docs = repo.documents_for_lazy_attribute(:city_names, Esse::LazyDocumentHeader.coerce(id: '2'))
+        expect(docs).to eq([
+          Esse::HashDocument.new(_id: '2', city_names: 'London')
+        ])
+      end
+    end
+
+    context 'when the attribute is defined and its result is hash with LazyDocumentHeader as key' do
+      let(:repo) do
+        Class.new(Esse::Repository) do
+          lazy_document_attribute :city_names do |docs|
+            {
+              Esse::LazyDocumentHeader.coerce(id: '1') => 'Moscow',
+              Esse::LazyDocumentHeader.coerce(id: '2') => 'London',
+            }
+          end
+        end
+      end
+
+      it 'returns an empty array when no ids are provided' do
+        expect(repo.documents_for_lazy_attribute(:city_names)).to eq([])
+      end
+
+      it 'returns an empty array when no ids are found' do
+        expect(repo.documents_for_lazy_attribute(:city_names, '3')).to eq([])
+      end
+
+      it 'returns an array of documents that match with the provided ids' do
+        docs = repo.documents_for_lazy_attribute(:city_names, '2')
+        expect(docs).to eq([
+          Esse::HashDocument.new(_id: '2', city_names: 'London')
+        ])
+      end
+
+      it 'returns an array of documents that match with the provided LazyDocumentHeader' do
+        docs = repo.documents_for_lazy_attribute(:city_names, Esse::LazyDocumentHeader.coerce(id: '2'))
+        expect(docs).to eq([
+          Esse::HashDocument.new(_id: '2', city_names: 'London')
+        ])
+      end
+
+      it 'do not include duplicate documents' do
+        docs = repo.documents_for_lazy_attribute(:city_names, '2', '2', Esse::LazyDocumentHeader.coerce(id: '2'))
+        expect(docs).to eq([
+          Esse::HashDocument.new(_id: '2', city_names: 'London')
+        ])
+      end
+    end
+
+    context 'when the result is a hash includes blank values' do
+      let(:repo) do
+        Class.new(Esse::Repository) do
+          lazy_document_attribute :city_names do |docs|
+            {
+              '1' => 'Moscow',
+              '2' => 'London',
+              '3' => nil,
+              '4' => '',
+            }
+          end
+        end
+      end
+
+      it 'returns an array of documents that match with the provided ids' do
+        docs = repo.documents_for_lazy_attribute(:city_names, '2', '3', '4')
+        expect(docs).to eq([
+          Esse::HashDocument.new(_id: '2', city_names: 'London'),
+          Esse::HashDocument.new(_id: '3', city_names: nil),
+          Esse::HashDocument.new(_id: '4', city_names: ''),
+        ])
+      end
+    end
+  end
+
+  describe '.update_documents_attribute' do
+    let(:repo) do
+      Class.new(Esse::Repository) do
+        lazy_document_attribute :city_names do |docs|
+          {
+            '1' => 'Moscow',
+            '2' => 'London',
+          }
+        end
+      end
+    end
+
+    it 'does nothing when no ids are provided' do
+      expect(repo.index).not_to receive(:bulk)
+      repo.update_documents_attribute(:city_names)
+    end
+
+    it 'does nothing when no ids are found' do
+      expect(repo.index).not_to receive(:bulk)
+      repo.update_documents_attribute(:city_names, '3')
+    end
+
+    it 'updates the documents' do
+      expect(repo.index).to receive(:bulk).with(
+        update: [
+          Esse::HashDocument.new(_id: '2', city_names: 'London')
+        ]
+      )
+      repo.update_documents_attribute(:city_names, '2')
+    end
+  end
+end

--- a/spec/support/shared_contexts/geos_index_definition.rb
+++ b/spec/support/shared_contexts/geos_index_definition.rb
@@ -82,6 +82,12 @@ RSpec.shared_context 'with geos index definition' do
           end
         end
         document documents.fetch(:county)
+        lazy_document_attribute :country do |docs|
+          docs.map { |doc| [doc, 'US'] }.to_h
+        end
+        lazy_document_attribute :cities do |docs|
+          docs.map { |doc| [doc, []] }.to_h
+        end
       end
     end
   end

--- a/spec/support/shared_examples/repository_documents_import.rb
+++ b/spec/support/shared_examples/repository_documents_import.rb
@@ -62,4 +62,44 @@ RSpec.shared_examples 'repository.import' do
       expect(GeosIndex.count).to eq(2)
     end
   end
+
+  context 'when the lazy_update_document_attributes is set' do
+    it 'indexes the data and bulk updates all the lazy document attributes' do
+      es_client do |client, _conf, cluster|
+        GeosIndex.create_index(alias: true)
+
+        resp = nil
+        expect {
+          resp = GeosIndex::County.import(lazy_update_document_attributes: true)
+        }.not_to raise_error
+        expect(resp).to eq(total_counties)
+
+        GeosIndex.refresh
+        expect(GeosIndex.count).to eq(total_counties)
+
+        doc = GeosIndex.get(id: '888')
+        expect(doc.dig('_source', 'country')).to eq('US')
+        expect(doc.dig('_source', 'cities')).to eq([])
+      end
+    end
+
+    it 'indexes the data and bulk updates given lazy document attribute' do
+      es_client do |client, _conf, cluster|
+        GeosIndex.create_index(alias: true)
+
+        resp = nil
+        expect {
+          resp = GeosIndex::County.import(lazy_update_document_attributes: %i[country])
+        }.not_to raise_error
+        expect(resp).to eq(total_counties)
+
+        GeosIndex.refresh
+        expect(GeosIndex.count).to eq(total_counties)
+
+        doc = GeosIndex.get(id: '888')
+        expect(doc.dig('_source', 'country')).to eq('US')
+        expect(doc.dig('_source', 'cities')).to eq(nil)
+      end
+    end
+  end
 end

--- a/spec/support/shared_examples/repository_documents_import.rb
+++ b/spec/support/shared_examples/repository_documents_import.rb
@@ -102,4 +102,44 @@ RSpec.shared_examples 'repository.import' do
       end
     end
   end
+
+  context 'when the eager_include_document_attributes is set' do
+    it 'indexes the data and bulk updates all the eager document attributes' do
+      es_client do |client, _conf, cluster|
+        GeosIndex.create_index(alias: true)
+
+        resp = nil
+        expect {
+          resp = GeosIndex::County.import(eager_include_document_attributes: true)
+        }.not_to raise_error
+        expect(resp).to eq(total_counties)
+
+        GeosIndex.refresh
+        expect(GeosIndex.count).to eq(total_counties)
+
+        doc = GeosIndex.get(id: '888')
+        expect(doc.dig('_source', 'country')).to eq('US')
+        expect(doc.dig('_source', 'cities')).to eq([])
+      end
+    end
+
+    it 'indexes the data and bulk updates given eager document attribute' do
+      es_client do |client, _conf, cluster|
+        GeosIndex.create_index(alias: true)
+
+        resp = nil
+        expect {
+          resp = GeosIndex::County.import(eager_include_document_attributes: %i[country])
+        }.not_to raise_error
+        expect(resp).to eq(total_counties)
+
+        GeosIndex.refresh
+        expect(GeosIndex.count).to eq(total_counties)
+
+        doc = GeosIndex.get(id: '888')
+        expect(doc.dig('_source', 'country')).to eq('US')
+        expect(doc.dig('_source', 'cities')).to eq(nil)
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Lazy Document attributes

The idea is to define document attributes that can be lazy loaded and updated using update or bulk update operations. This is useful for example when a document has nested and denormalized fields that are expensive to update the whole document. So, you can retrieve the value of the attribute and partially update the document.

The lazy document attribute can be defined on the index repository level:

```ruby
class PostsIndex < Esse::Index
  repository :post do
    colection do
      # ...
    end

    document do |post|
      {
        _id: post.id,
        title: post.title,
      }
    end

    lazy_document_attribute :comments do |posts|
      Comment.where(post_id: posts.map(&:id)).group(:post_id).transform_values(&:count)
    end
  end
end
```
_Note that the result of lazy_document_attribute is a hash where the key is one of the given post or its id_.

So you to partially update the document by updating the comments count:

```ruby
PostsIndex::Post.update_documents_attribute(:comments, postid1, postid2)
```

This could be part of some callback in the model or a background job.


You can also import documents by eager loading the lazy attribute or lazy loading it:

```ruby
# Eager loading it, means that the attribute will be added to the document before bulk indexing it
PostsIndex.import(context: context, eager_include_document_attributes: [:comments])

# Lazy loading it, means that the attribute will be add to the document with a bulk update request after bulk indexing it
PostsIndex.import(context: context, lazy_update_document_attributes: [:comments])
```
