### PR TITLE
chore: add --settings to the reset, create and update_settings index cli

### DIFF
--- a/lib/esse/cli/index.rb
+++ b/lib/esse/cli/index.rb
@@ -17,9 +17,11 @@ module Esse
       option :suffix, type: :string, default: nil, aliases: '-s', desc: 'Suffix to append to index name'
       option :import, type: :boolean, default: true, desc: 'Import documents before point alias to the new index'
       option :optimize, type: :boolean, default: true, desc: 'Optimize index before import documents by disabling refresh_interval and setting number_of_replicas to 0'
+      option :settings, type: :hash, default: nil, desc: 'List of settings to pass to the index class. Example: --settings=refresh_interval:1s,number_of_replicas:0'
       def reset(*index_classes)
         require_relative 'index/reset'
-        Reset.new(indices: index_classes, **options.to_h.transform_keys(&:to_sym)).run
+        opts = HashUtils.deep_transform_keys(options.to_h, &:to_sym)
+        Reset.new(indices: index_classes, **opts).run
       end
 
       # @TODO Add reindex task to create a new index and import documents from the old index using _reindex API
@@ -33,9 +35,11 @@ module Esse
       DESC
       option :suffix, type: :string, default: nil, aliases: '-s', desc: 'Suffix to append to index name'
       option :alias, type: :boolean, default: false, aliases: '-a', desc: 'Update alias after create index'
+      option :settings, type: :hash, default: nil, desc: 'List of settings to pass to the index class. Example: --settings=index.refresh_interval:-1,index.number_of_replicas:0'
       def create(*index_classes)
         require_relative 'index/create'
-        Create.new(indices: index_classes, **options.to_h.transform_keys(&:to_sym)).run
+        opts = HashUtils.deep_transform_keys(options.to_h, &:to_sym)
+        Create.new(indices: index_classes, **opts).run
       end
 
       desc 'delete *INDEX_CLASSES', 'Deletes indices for the given classes'
@@ -58,9 +62,11 @@ module Esse
       desc 'update_settings *INDEX_CLASS', 'Closes the index for read/write operations, updates the index settings, and open it again'
       option :suffix, type: :string, default: nil, aliases: '-s', desc: 'Suffix to append to index name'
       option :type, type: :string, default: nil, aliases: '-t', desc: 'Document Type to update mapping for'
+      option :settings, type: :hash, default: nil, desc: 'List of settings to pass to the index class. Example: --settings=index.refresh_interval:-1,index.number_of_replicas:0'
       def update_settings(*index_classes)
         require_relative 'index/update_settings'
-        UpdateSettings.new(indices: index_classes, **options.to_h.transform_keys(&:to_sym)).run
+        opts = HashUtils.deep_transform_keys(options.to_h, &:to_sym)
+        UpdateSettings.new(indices: index_classes, **opts).run
       end
 
       desc 'update_mapping *INDEX_CLASS', 'Create or update a mapping'
@@ -89,8 +95,8 @@ module Esse
       option :suffix, type: :string, default: nil, aliases: '-s', desc: 'Suffix to append to index name'
       option :context, type: :hash, default: {}, required: true, desc: 'List of options to pass to the index class'
       option :repo, type: :string, default: nil, alias: '-r', desc: 'Repository to use for import'
-      option :eager_include_document_attributes, type: :string, default: nil, desc: 'Comma separated list of lazy document attributes to include to the bulk index request'
-      option :lazy_update_document_attributes, type: :string, default: nil, desc: 'Comma separated list of lazy document attributes to bulk update after the bulk index request'
+      option :eager_include_document_attributes, type: :string, default: nil, desc: 'Comma separated list of lazy document attributes to include to the bulk index request. Or pass `true` to include all lazy attributes'
+      option :lazy_update_document_attributes, type: :string, default: nil, desc: 'Comma separated list of lazy document attributes to bulk update after the bulk index request Or pass `true` to include all lazy attributes'
       def import(*index_classes)
         require_relative 'index/import'
         opts = HashUtils.deep_transform_keys(options.to_h, &:to_sym)

--- a/lib/esse/cli/templates/config.rb.erb
+++ b/lib/esse/cli/templates/config.rb.erb
@@ -13,8 +13,10 @@ Esse.configure do |config|
 
     # Global index settings
     #   cluster.settings = {
-    #     number_of_shards: 5,
-    #     number_of_replicas: 0,
+    #     index: {
+    #       number_of_shards: 5,
+    #       number_of_replicas: 0,
+    #     }
     #   }
 
     # Global index mappings

--- a/lib/esse/config.rb
+++ b/lib/esse/config.rb
@@ -10,8 +10,11 @@ module Esse
   #       cluster.index_prefix = 'backend'
   #       cluster.client = Elasticsearch::Client.new
   #       cluster.settings = {
-  #         number_of_shards: 2,
-  #         number_of_replicas: 0
+  #         index: {
+  #           number_of_shards: 2,
+  #           number_of_replicas: 1
+  #         },
+  #         analysis: { ... }
   #       }
   #       cluster.mappings = {
   #         dynamic_templates: [...]

--- a/lib/esse/primitives/hash_utils.rb
+++ b/lib/esse/primitives/hash_utils.rb
@@ -47,5 +47,15 @@ module Esse
         end
       end
     end
+
+    def explode_keys(hash, separator = '.')
+      hash.each_with_object({}) do |(key, value), result|
+        is_symbol = key.is_a?(Symbol)
+        keys = key.to_s.split(separator)
+        last_key = keys.pop
+        current = keys.reduce(result) { |memo, k| memo[is_symbol ? k.to_sym : k] ||= {} }
+        current[is_symbol ? last_key.to_sym : last_key] = value
+      end
+    end
   end
 end

--- a/spec/esse/cli/index/create_spec.rb
+++ b/spec/esse/cli/index/create_spec.rb
@@ -49,6 +49,11 @@ RSpec.describe Esse::CLI::Index, type: :cli do
         expect(CitiesIndex).to receive(:create_index).with(alias: false).and_return(true)
         cli_exec(%w[index create CountiesIndex CitiesIndex])
       end
+
+      it 'allows to pass --settings as a hash with imploded values' do
+        expect(CountiesIndex).to receive(:create_index).with(alias: false, settings: { 'index.refresh_interval': '1s' }).and_return(true)
+        cli_exec(%w[index create CountiesIndex --settings=index.refresh_interval:1s])
+      end
     end
   end
 end

--- a/spec/esse/cli/index/reset_spec.rb
+++ b/spec/esse/cli/index/reset_spec.rb
@@ -55,6 +55,11 @@ RSpec.describe Esse::CLI::Index, type: :cli do
         expect(CountiesIndex).to receive(:reset_index).with(import: true, optimize: false).and_return(true)
         cli_exec(%w[index reset CountiesIndex --no-optimize])
       end
+
+      it 'allows to pass --settings as a hash with imploded values' do
+        expect(CountiesIndex).to receive(:reset_index).with(import: true,  optimize: true, settings: { 'index.refresh_interval': '-1' }).and_return(true)
+        cli_exec(%w[index reset CountiesIndex --settings=index.refresh_interval:-1])
+      end
     end
   end
 end

--- a/spec/esse/cli/index/update_settings_spec.rb
+++ b/spec/esse/cli/index/update_settings_spec.rb
@@ -44,6 +44,11 @@ RSpec.describe Esse::CLI::Index, type: :cli do
         expect(CitiesIndex).to receive(:update_settings).and_return(true)
         cli_exec(%w[index update_settings CountiesIndex CitiesIndex])
       end
+
+      it 'allows to pass --settings as a hash with imploded values' do
+        expect(CountiesIndex).to receive(:update_settings).with(settings: { 'index.refresh_interval': '1s' }).and_return(true)
+        cli_exec(%w[index update_settings CountiesIndex --settings=index.refresh_interval:1s])
+      end
     end
   end
 end

--- a/spec/esse/index/settings_spec.rb
+++ b/spec/esse/index/settings_spec.rb
@@ -20,18 +20,18 @@ RSpec.describe Esse::Index do
 
     context 'with a hash definition' do
       before do
-        stub_index(:events) { settings(number_of_replicas: 4) }
+        stub_index(:events) { settings(index: { number_of_replicas: 4 }) }
       end
 
-      specify do
+      it 'returns the settings hash form index settings' do
         with_cluster_config(settings: {}) do
-          expect(subject).to eq(number_of_replicas: 4)
+          expect(subject).to eq(index: { number_of_replicas: 4 })
         end
       end
 
-      specify do
-        with_cluster_config(settings: { number_of_replicas: 3, refresh_interval: '1s' }) do
-          expect(subject).to eq(number_of_replicas: 4, refresh_interval: '1s')
+      it 'merges the settings with the cluster settings' do
+        with_cluster_config(settings: { index: { number_of_replicas: 3, refresh_interval: '1s' } }) do
+          expect(subject).to eq(index: { number_of_replicas: 4, refresh_interval: '1s' })
         end
       end
     end
@@ -40,57 +40,121 @@ RSpec.describe Esse::Index do
       before do
         stub_index(:events) do
           settings do
-            { number_of_replicas: '4'.to_i }
+            { index: { number_of_replicas: '4'.to_i } }
           end
         end
       end
 
-      specify do
-        expect(subject).to eq(number_of_replicas: 4)
+      it 'returns the settings hash form index settings' do
+        expect(subject).to eq(index: { number_of_replicas: 4 })
       end
 
-      specify do
-        with_cluster_config(settings: { number_of_replicas: 3, refresh_interval: '1s' }) do
-          expect(subject).to eq(number_of_replicas: 4, refresh_interval: '1s')
+      it 'merges the settings with the cluster settings' do
+        with_cluster_config(settings: { index: { number_of_replicas: 3, refresh_interval: '1s' } }) do
+          expect(subject).to eq(index: { number_of_replicas: 4, refresh_interval: '1s' })
         end
       end
     end
   end
 
   describe '.settings_hash' do
-    context 'without the settings node' do
+    context 'with imploded settings' do
       before do
         stub_index(:geos) do
           settings do
-            { 'number_of_replicas' => '4'.to_i }
+            { 'index.number_of_replicas' => '4'.to_i }
+          end
+        end
+      end
+
+      it 'explodes the settings' do
+        expect(GeosIndex.settings_hash).to eq(
+          settings: { index: { number_of_replicas: 4 } },
+        )
+      end
+    end
+
+    context 'with simplified settings' do
+      before do
+        stub_index(:geos) do
+          settings do
+            {
+              number_of_shards: 1,
+              number_of_replicas: 4,
+              refresh_interval: '1s',
+            }
+          end
+        end
+      end
+
+      it 'moves the simplified settings to the :index key' do
+        expect(GeosIndex.settings_hash).to eq(
+          settings: { index: {
+            number_of_shards: 1,
+            number_of_replicas: 4,
+            refresh_interval: '1s'
+          } },
+        )
+      end
+    end
+
+    context 'without the settings root key' do
+      before do
+        stub_index(:geos) do
+          settings do
+            { 'index' => { 'number_of_replicas' => '4'.to_i } }
           end
         end
       end
 
       specify do
         expect(GeosIndex.settings_hash).to eq(
-          settings: { number_of_replicas: 4 },
+          settings: { index: { number_of_replicas: 4 } },
         )
       end
 
       specify do
-        with_cluster_config(settings: { refresh_interval: '1s', number_of_replicas: 2 }) do
+        with_cluster_config(settings: { index: { refresh_interval: '1s', number_of_replicas: 2 } }) do
           expect(GeosIndex.settings_hash).to eq(
             settings: {
-              refresh_interval: '1s',
-              number_of_replicas: 4,
+              index: {
+                refresh_interval: '1s',
+                number_of_replicas: 4,
+              }
             },
           )
         end
       end
+
+      it 'merges the given settings with the index settings' do
+        expect(GeosIndex.settings_hash(settings: { index: { refresh_interval: '-1' } })).to eq(
+          settings: {
+            index: {
+              refresh_interval: '-1',
+              number_of_replicas: 4,
+            }
+          }
+        )
+      end
+
+      it 'merges the given imploded settings with the index settings' do
+        expect(GeosIndex.settings_hash(settings: { 'index.refresh_interval': '-1' })).to eq(
+          settings: {
+            index: {
+              refresh_interval: '-1',
+              number_of_replicas: 4,
+            }
+          }
+        )
+      end
     end
 
-    context 'with the settings node' do
+    context 'with the settings root key' do
       before do
         stub_index(:geos) do
           settings do
             {
-              'settings' => { 'number_of_replicas' => '6'.to_i },
+              'settings' => { 'index' => { 'number_of_replicas' => '6'.to_i } },
             }
           end
         end
@@ -98,7 +162,7 @@ RSpec.describe Esse::Index do
 
       specify do
         expect(GeosIndex.settings_hash).to eq(
-          settings: { number_of_replicas: 6 },
+          settings: { index: { number_of_replicas: 6 } },
         )
       end
     end

--- a/spec/esse/integrations/elasticsearch-1/index/create_index_spec.rb
+++ b/spec/esse/integrations/elasticsearch-1/index/create_index_spec.rb
@@ -11,8 +11,10 @@ stack_describe 'elasticsearch', '1.x', Esse::Index, '.create_index' do
       stub_index(:dummies) do
         settings do
           {
-            number_of_shards: 1,
-            number_of_replicas: 0,
+            index: {
+              number_of_shards: 1,
+              number_of_replicas: 0,
+            }
           }
         end
         mappings do

--- a/spec/esse/integrations/elasticsearch-1/transport/update_mapping_spec.rb
+++ b/spec/esse/integrations/elasticsearch-1/transport/update_mapping_spec.rb
@@ -15,7 +15,7 @@ stack_describe 'elasticsearch', '1.x', Esse::Transport, '#update_mapping' do
     es_client do |client, _conf, cluster|
       index_name = "#{cluster.index_prefix}_dummies_v1"
       cluster.api.create_index(index: index_name, body: {
-        settings: { number_of_shards: 1, number_of_replicas: 0 },
+        settings: { index: { number_of_shards: 1, number_of_replicas: 0 } },
       })
 
       expect {

--- a/spec/esse/integrations/elasticsearch-2/index/create_index_spec.rb
+++ b/spec/esse/integrations/elasticsearch-2/index/create_index_spec.rb
@@ -11,8 +11,10 @@ stack_describe 'elasticsearch', '2.x', Esse::Index, '.create_index' do
       stub_index(:dummies) do
         settings do
           {
-            number_of_shards: 1,
-            number_of_replicas: 0,
+            index: {
+              number_of_shards: 1,
+              number_of_replicas: 0,
+            }
           }
         end
         mappings do

--- a/spec/esse/integrations/elasticsearch-2/transport/update_mapping_spec.rb
+++ b/spec/esse/integrations/elasticsearch-2/transport/update_mapping_spec.rb
@@ -15,7 +15,7 @@ stack_describe 'elasticsearch', '2.x', Esse::Transport, '#update_mapping' do
     es_client do |client, _conf, cluster|
       index_name = "#{cluster.index_prefix}_dummies_v1"
       cluster.api.create_index(index: index_name, body: {
-        settings: { number_of_shards: 1, number_of_replicas: 0 },
+        settings: { index: { number_of_shards: 1, number_of_replicas: 0 } },
       })
       cluster.api.refresh(index: index_name)
 

--- a/spec/esse/integrations/elasticsearch-5/index/create_index_spec.rb
+++ b/spec/esse/integrations/elasticsearch-5/index/create_index_spec.rb
@@ -11,8 +11,10 @@ stack_describe 'elasticsearch', '5.x', Esse::Index, '.create_index' do
       stub_index(:dummies) do
         settings do
           {
-            number_of_shards: 1,
-            number_of_replicas: 0,
+            index: {
+              number_of_shards: 1,
+              number_of_replicas: 0,
+            }
           }
         end
         mappings do

--- a/spec/esse/integrations/elasticsearch-5/transport/update_mapping_spec.rb
+++ b/spec/esse/integrations/elasticsearch-5/transport/update_mapping_spec.rb
@@ -15,7 +15,7 @@ stack_describe 'elasticsearch', '5.x', Esse::Transport, '#update_mapping' do
     es_client do |client, _conf, cluster|
       index_name = "#{cluster.index_prefix}_dummies_v1"
       cluster.api.create_index(index: index_name, body: {
-        settings: { number_of_shards: 1, number_of_replicas: 0 },
+        settings: { index: { number_of_shards: 1, number_of_replicas: 0 } },
       })
 
       expect {

--- a/spec/esse/integrations/elasticsearch-6/index/create_index_spec.rb
+++ b/spec/esse/integrations/elasticsearch-6/index/create_index_spec.rb
@@ -11,8 +11,10 @@ stack_describe 'elasticsearch', '6.x', Esse::Index, '.create_index' do
       stub_index(:dummies) do
         settings do
           {
-            number_of_shards: 1,
-            number_of_replicas: 0,
+            index: {
+              number_of_shards: 1,
+              number_of_replicas: 0,
+            }
           }
         end
         mappings do

--- a/spec/esse/integrations/elasticsearch-6/transport/update_mapping_spec.rb
+++ b/spec/esse/integrations/elasticsearch-6/transport/update_mapping_spec.rb
@@ -15,7 +15,7 @@ stack_describe 'elasticsearch', '6.x', Esse::Transport, '#update_mapping' do
     es_client do |client, _conf, cluster|
       index_name = "#{cluster.index_prefix}_dummies_v1"
       cluster.api.create_index(index: index_name, body: {
-        settings: { number_of_shards: 1, number_of_replicas: 0 },
+        settings: { index: { number_of_shards: 1, number_of_replicas: 0 } },
       })
 
       expect {

--- a/spec/esse/integrations/elasticsearch-7/index/create_index_spec.rb
+++ b/spec/esse/integrations/elasticsearch-7/index/create_index_spec.rb
@@ -11,8 +11,10 @@ stack_describe 'elasticsearch', '7.x', Esse::Index, '.create_index' do
       stub_index(:dummies) do
         settings do
           {
-            number_of_shards: 1,
-            number_of_replicas: 0
+            index: {
+              number_of_shards: 1,
+              number_of_replicas: 0
+            }
           }
         end
         mappings do

--- a/spec/esse/integrations/elasticsearch-8/transport/create_index_spec.rb
+++ b/spec/esse/integrations/elasticsearch-8/transport/create_index_spec.rb
@@ -11,8 +11,10 @@ stack_describe 'elasticsearch', '8.x', Esse::Transport, '#create_index' do
       stub_index(:dummies) do
         settings do
           {
-            number_of_shards: 1,
-            number_of_replicas: 0
+            index: {
+              number_of_shards: 1,
+              number_of_replicas: 0
+            }
           }
         end
         mappings do

--- a/spec/esse/primitives/hash_utils_spec.rb
+++ b/spec/esse/primitives/hash_utils_spec.rb
@@ -8,4 +8,28 @@ RSpec.describe Esse::HashUtils do
       expect(described_class.deep_transform_keys({'a' => {'b' => 'c'}}, &:to_sym)).to eq(a: {b: 'c'})
     end
   end
+
+  describe '#deep_merge' do
+    specify do
+      expect(described_class.deep_merge({a: {b: 'c'}}, {a: {d: 'e'}})).to eq(a: {b: 'c', d: 'e'})
+    end
+  end
+
+  describe '#deep_merge!' do
+    specify do
+      hash = {a: {b: 'c'}}
+      described_class.deep_merge!(hash, {a: {d: 'e'}})
+      expect(hash).to eq(a: {b: 'c', d: 'e'})
+    end
+  end
+
+  describe '#explode_keys' do
+    specify do
+      expect(described_class.explode_keys({'a.b' => 'c'})).to eq('a' => {'b' => 'c'})
+    end
+
+    specify do
+      expect(described_class.explode_keys({'a.b.c': 'd'})).to eq(a: {b: {c: 'd'}})
+    end
+  end
 end

--- a/spec/fixtures/config/esse_with_clusters.yml
+++ b/spec/fixtures/config/esse_with_clusters.yml
@@ -4,10 +4,12 @@ clusters:
   v1:
     index_prefix: esse_test_v1
     settings:
-      number_of_shards: 1
-      number_of_replicas: 1
+      index:
+        number_of_shards: 5
+        number_of_replicas: 1
   v2:
     index_prefix: esse_test_v2
     settings:
-      number_of_shards: 2
-      number_of_replicas: 2
+      index:
+        number_of_shards: 3
+        number_of_replicas: 1

--- a/spec/support/config_helpers.rb
+++ b/spec/support/config_helpers.rb
@@ -8,8 +8,10 @@ module ConfigHelpers
         client: { url: ENV.fetch('ESSE_URL', ENV.fetch('ELASTICSEARCH_URL', 'http://localhost:9200')) },
         index_prefix: 'esse_test',
         settings: {
-          number_of_shards: 1,
-          number_of_replicas: 0,
+          index: {
+            number_of_shards: 1,
+            number_of_replicas: 0,
+          }
         },
         mappings: {},
         readonly: false,

--- a/spec/support/shared_examples/index_create_index.rb
+++ b/spec/support/shared_examples/index_create_index.rb
@@ -51,7 +51,7 @@ RSpec.shared_examples 'index.create_index' do
 
   it 'uses the settings_hash and settings_hash as default definition' do
     es_client do |client, _conf, cluster|
-      expect(GeosIndex).to receive(:settings_hash).and_return({ settings: { number_of_shards: 1 } })
+      expect(GeosIndex).to receive(:settings_hash).and_return({ settings: { index: { number_of_shards: 1 } } })
       expect(GeosIndex).to receive(:mappings_hash).and_return({ mappings: { } })
       allow(Esse).to receive(:timestamp).and_return('20220101')
 
@@ -59,7 +59,7 @@ RSpec.shared_examples 'index.create_index' do
       allow(cluster).to receive(:api).and_return(api)
       expect(api).to receive(:create_index).with(
         index: GeosIndex.index_name(suffix: '20220101'),
-        body: { aliases: { GeosIndex.index_name => {} }, settings: { number_of_shards: 1 }, mappings: { } },
+        body: { aliases: { GeosIndex.index_name => {} }, settings: { index: { number_of_shards: 1 } }, mappings: { } },
       ).and_call_original
 
       expect {

--- a/spec/support/shared_examples/index_delete_index.rb
+++ b/spec/support/shared_examples/index_delete_index.rb
@@ -53,7 +53,7 @@ RSpec.shared_examples 'index.delete_index' do
   it 'deletes the index created with root naming' do
     es_client do |client, _conf, cluster|
       cluster.api.create_index(index: VenuesIndex.index_name, body: {
-        settings: { number_of_shards: 1, number_of_replicas: 0 },
+        settings: { index: { number_of_shards: 1, number_of_replicas: 0 } },
       })
 
       resp = nil

--- a/spec/support/shared_examples/transport_aliases.rb
+++ b/spec/support/shared_examples/transport_aliases.rb
@@ -5,7 +5,7 @@ RSpec.shared_examples 'transport#aliases' do
     es_client do |client, _conf, cluster|
       cluster.api.create_index(index: "#{cluster.index_prefix}_dummies_v1", body: {
         aliases: { "#{cluster.index_prefix}_dummies" => {} },
-        settings: { number_of_shards: 1, number_of_replicas: 0 },
+        settings: { index: { number_of_shards: 1, number_of_replicas: 0 } },
       })
 
       expect(cluster.api.aliases(index: "#{cluster.index_prefix}_dummies", name: '*')).to eq(
@@ -18,7 +18,7 @@ RSpec.shared_examples 'transport#aliases' do
     es_client do |client, _conf, cluster|
       cluster.api.create_index(index: "#{cluster.index_prefix}_dummies_v1", body: {
         aliases: { "#{cluster.index_prefix}_dummies" => {} },
-        settings: { number_of_shards: 1, number_of_replicas: 0 },
+        settings: { index: { number_of_shards: 1, number_of_replicas: 0 } },
       })
 
       cluster.readonly = true

--- a/spec/support/shared_examples/transport_close.rb
+++ b/spec/support/shared_examples/transport_close.rb
@@ -26,7 +26,7 @@ RSpec.shared_examples 'transport#close' do
     es_client do |_client, _conf, cluster|
       index_name = "#{cluster.index_prefix}_dummies_#{index_suffix}"
       cluster.api.create_index(index: index_name, body: {
-        settings: { number_of_shards: 1, number_of_replicas: 0 },
+        settings: { index: { number_of_shards: 1, number_of_replicas: 0 } },
       })
 
       cluster.wait_for_status!(index: index_name)

--- a/spec/support/shared_examples/transport_create_index.rb
+++ b/spec/support/shared_examples/transport_create_index.rb
@@ -4,8 +4,10 @@ RSpec.shared_examples 'transport#create_index' do
   let(:body) do
     {
       settings: {
-        number_of_shards: 1,
-        number_of_replicas: 0
+        index: {
+          number_of_shards: 1,
+          number_of_replicas: 0
+        }
       }
     }
   end

--- a/spec/support/shared_examples/transport_delete_index.rb
+++ b/spec/support/shared_examples/transport_delete_index.rb
@@ -24,7 +24,7 @@ RSpec.shared_examples 'transport#delete_index' do
     es_client do |client, _conf, cluster|
       index_name = "#{cluster.index_prefix}_dummies_v1"
       cluster.api.create_index(index: index_name, body: {
-        settings: { number_of_shards: 1, number_of_replicas: 0 },
+        settings: { index: { number_of_shards: 1, number_of_replicas: 0 } },
       })
 
       resp = nil

--- a/spec/support/shared_examples/transport_documents_bulk.rb
+++ b/spec/support/shared_examples/transport_documents_bulk.rb
@@ -18,7 +18,7 @@ RSpec.shared_examples 'transport#bulk' do
     es_client do |_client, _conf, cluster|
       index_name = "#{cluster.index_prefix}_dummies_#{index_suffix}"
       cluster.api.create_index(index: index_name, body: {
-        settings: { number_of_shards: 1, number_of_replicas: 0 },
+        settings: { index: { number_of_shards: 1, number_of_replicas: 0 } },
       })
 
       payload = <<~PAYLOAD
@@ -44,7 +44,7 @@ RSpec.shared_examples 'transport#bulk' do
     es_client do |_client, _conf, cluster|
       index_name = "#{cluster.index_prefix}_dummies_#{index_suffix}"
       cluster.api.create_index(index: index_name, body: {
-        settings: { number_of_shards: 1, number_of_replicas: 0 },
+        settings: { index: { number_of_shards: 1, number_of_replicas: 0 } },
       })
 
       payload = [
@@ -70,7 +70,7 @@ RSpec.shared_examples 'transport#bulk' do
     es_client do |_client, _conf, cluster|
       index_name = "#{cluster.index_prefix}_dummies_#{index_suffix}"
       cluster.api.create_index(index: index_name, body: {
-        settings: { number_of_shards: 1, number_of_replicas: 0 },
+        settings: { index: { number_of_shards: 1, number_of_replicas: 0 } },
       })
 
       payload = [

--- a/spec/support/shared_examples/transport_documents_count.rb
+++ b/spec/support/shared_examples/transport_documents_count.rb
@@ -10,7 +10,7 @@ RSpec.shared_examples 'transport#count' do |doc_type: false|
     es_client do |_client, _conf, cluster|
       index_name = "#{cluster.index_prefix}_dummies_#{index_suffix}"
       cluster.api.create_index(index: index_name, body: {
-        settings: { number_of_shards: 1, number_of_replicas: 0 },
+        settings: { index: { number_of_shards: 1, number_of_replicas: 0 } },
       })
       cluster.api.index(index: index_name, id: 1, body: { name: 'Illinois', pk: 1 }, refresh: true, **params)
 
@@ -26,7 +26,7 @@ RSpec.shared_examples 'transport#count' do |doc_type: false|
     es_client do |_client, _conf, cluster|
       index_name = "#{cluster.index_prefix}_dummies_#{index_suffix}"
       cluster.api.create_index(index: index_name, body: {
-        settings: { number_of_shards: 1, number_of_replicas: 0 },
+        settings: { index: { number_of_shards: 1, number_of_replicas: 0 } },
       })
 
       cluster.readonly = true

--- a/spec/support/shared_examples/transport_documents_delete.rb
+++ b/spec/support/shared_examples/transport_documents_delete.rb
@@ -21,7 +21,7 @@ RSpec.shared_examples 'transport#delete' do |doc_type: false|
     es_client do |_client, _conf, cluster|
       index_name = "#{cluster.index_prefix}_dummies_#{index_suffix}"
       cluster.api.create_index(index: index_name, body: {
-        settings: { number_of_shards: 1, number_of_replicas: 0 },
+        settings: { index: { number_of_shards: 1, number_of_replicas: 0 } },
       })
       cluster.api.index(index: index_name, id: 1, body: { name: 'Illinois', pk: 1 }, **params)
 
@@ -38,7 +38,7 @@ RSpec.shared_examples 'transport#delete' do |doc_type: false|
     es_client do |_client, _conf, cluster|
       index_name = "#{cluster.index_prefix}_dummies_#{index_suffix}"
       cluster.api.create_index(index: index_name, body: {
-        settings: { number_of_shards: 1, number_of_replicas: 0 },
+        settings: { index: { number_of_shards: 1, number_of_replicas: 0 } },
       })
 
       expect {

--- a/spec/support/shared_examples/transport_documents_exist.rb
+++ b/spec/support/shared_examples/transport_documents_exist.rb
@@ -10,7 +10,7 @@ RSpec.shared_examples 'transport#exist?' do |doc_type: false|
     es_client do |_client, _conf, cluster|
       index_name = "#{cluster.index_prefix}_dummies_#{index_suffix}"
       cluster.api.create_index(index: index_name, body: {
-        settings: { number_of_shards: 1, number_of_replicas: 0 },
+        settings: { index: { number_of_shards: 1, number_of_replicas: 0 } },
       })
       cluster.api.index(index: index_name, id: 1, body: { name: 'Illinois', pk: 1 }, refresh: true, **params)
 
@@ -26,7 +26,7 @@ RSpec.shared_examples 'transport#exist?' do |doc_type: false|
     es_client do |_client, _conf, cluster|
       index_name = "#{cluster.index_prefix}_dummies_#{index_suffix}"
       cluster.api.create_index(index: index_name, body: {
-        settings: { number_of_shards: 1, number_of_replicas: 0 },
+        settings: { index: { number_of_shards: 1, number_of_replicas: 0 } },
       })
       cluster.api.refresh(index: index_name)
 

--- a/spec/support/shared_examples/transport_documents_get.rb
+++ b/spec/support/shared_examples/transport_documents_get.rb
@@ -10,7 +10,7 @@ RSpec.shared_examples 'transport#get' do |doc_type: false|
     es_client do |_client, _conf, cluster|
       index_name = "#{cluster.index_prefix}_dummies_#{index_suffix}"
       cluster.api.create_index(index: index_name, body: {
-        settings: { number_of_shards: 1, number_of_replicas: 0 },
+        settings: { index: { number_of_shards: 1, number_of_replicas: 0 } },
       })
       cluster.api.index(index: index_name, id: 1, body: { name: 'Illinois', pk: 1 }, refresh: true, **params)
 
@@ -39,7 +39,7 @@ RSpec.shared_examples 'transport#get' do |doc_type: false|
     es_client do |_client, _conf, cluster|
       index_name = "#{cluster.index_prefix}_dummies_#{index_suffix}"
       cluster.api.create_index(index: index_name, body: {
-        settings: { number_of_shards: 1, number_of_replicas: 0 },
+        settings: { index: { number_of_shards: 1, number_of_replicas: 0 } },
       })
       cluster.api.index(index: index_name, id: 1, body: { name: 'Illinois', pk: 1 }, refresh: true, **params)
 

--- a/spec/support/shared_examples/transport_documents_index.rb
+++ b/spec/support/shared_examples/transport_documents_index.rb
@@ -20,7 +20,7 @@ RSpec.shared_examples 'transport#index' do |doc_type: false|
     es_client do |_client, _conf, cluster|
       index_name = "#{cluster.index_prefix}_dummies_#{SecureRandom.hex(8)}}"
       cluster.api.create_index(index: index_name, body: {
-        settings: { number_of_shards: 1, number_of_replicas: 0 },
+        settings: { index: { number_of_shards: 1, number_of_replicas: 0 } },
       })
       resp = nil
       expect {

--- a/spec/support/shared_examples/transport_documents_update.rb
+++ b/spec/support/shared_examples/transport_documents_update.rb
@@ -25,7 +25,7 @@ RSpec.shared_examples 'transport#update' do |doc_type: false|
     es_client do |_client, _conf, cluster|
       index_name = "#{cluster.index_prefix}_dummies_#{SecureRandom.hex(8)}}"
       cluster.api.create_index(index: index_name, body: {
-        settings: { number_of_shards: 1, number_of_replicas: 0 },
+        settings: { index: { number_of_shards: 1, number_of_replicas: 0 } },
       })
       cluster.api.index(index: index_name, id: 1, body: { name: 'Illinois', pk: 1 }, refresh: true, **params)
 
@@ -43,7 +43,7 @@ RSpec.shared_examples 'transport#update' do |doc_type: false|
     es_client do |_client, _conf, cluster|
       index_name = "#{cluster.index_prefix}_dummies_#{SecureRandom.hex(8)}}"
       cluster.api.create_index(index: index_name, body: {
-        settings: { number_of_shards: 1, number_of_replicas: 0 },
+        settings: { index: { number_of_shards: 1, number_of_replicas: 0 } },
       })
 
       expect {

--- a/spec/support/shared_examples/transport_open.rb
+++ b/spec/support/shared_examples/transport_open.rb
@@ -26,7 +26,7 @@ RSpec.shared_examples 'transport#open' do
     es_client do |client, _conf, cluster|
       index_name = "#{cluster.index_prefix}_dummies_#{index_suffix}"
       cluster.api.create_index(index: index_name, body: {
-        settings: { number_of_shards: 1, number_of_replicas: 0 },
+        settings: { index: { number_of_shards: 1, number_of_replicas: 0 } },
       })
       cluster.wait_for_status!(index: index_name)
       if %w[1.x 2.x].include?(example.metadata[:es_version])

--- a/spec/support/shared_examples/transport_refresh.rb
+++ b/spec/support/shared_examples/transport_refresh.rb
@@ -24,7 +24,7 @@ RSpec.shared_examples 'transport#refresh' do
     es_client do |client, _conf, cluster|
       index_name = "#{cluster.index_prefix}_dummies_v1"
       cluster.api.create_index(index: index_name, body: {
-        settings: { number_of_shards: 1, number_of_replicas: 0 },
+        settings: { index: { number_of_shards: 1, number_of_replicas: 0 } },
       })
 
       resp = nil

--- a/spec/support/shared_examples/transport_update_aliases.rb
+++ b/spec/support/shared_examples/transport_update_aliases.rb
@@ -23,7 +23,7 @@ RSpec.shared_examples 'transport#update_aliases' do
   it 'adds an alias to an index' do
     es_client do |client, _conf, cluster|
       cluster.api.create_index(index: "#{cluster.index_prefix}_dummies_v1", body: {
-        settings: { number_of_shards: 1, number_of_replicas: 0 },
+        settings: { index: { number_of_shards: 1, number_of_replicas: 0 } },
       })
 
       expect {
@@ -42,10 +42,10 @@ RSpec.shared_examples 'transport#update_aliases' do
     es_client do |client, _conf, cluster|
       cluster.api.create_index(index: "#{cluster.index_prefix}_dummies_v1", body: {
         aliases: { "#{cluster.index_prefix}_dummies" => {} },
-        settings: { number_of_shards: 1, number_of_replicas: 0 },
+        settings: { index: { number_of_shards: 1, number_of_replicas: 0 } },
       })
       cluster.api.create_index(index: "#{cluster.index_prefix}_dummies_v2", body: {
-        settings: { number_of_shards: 1, number_of_replicas: 0 },
+        settings: { index: { number_of_shards: 1, number_of_replicas: 0 } },
       })
 
       expect {

--- a/spec/support/shared_examples/transport_update_mapping.rb
+++ b/spec/support/shared_examples/transport_update_mapping.rb
@@ -24,7 +24,7 @@ RSpec.shared_examples 'transport#update_mapping' do
     es_client do |client, _conf, cluster|
       index_name = "#{cluster.index_prefix}_dummies_v1"
       cluster.api.create_index(index: index_name, body: {
-        settings: { number_of_shards: 1, number_of_replicas: 0 },
+        settings: { index: { number_of_shards: 1, number_of_replicas: 0 } },
       })
 
       expect {


### PR DESCRIPTION
the `--settings:hash` can be passed to the cli commandsd that involve index creation or settings update.

Example:

```bash
bundle exec esse index create OrganizationsIndex --settings=index.refresh_interval:30s
```