### PR TITLE
reset index using `/_reindex` API

### DIFF
--- a/lib/esse/cli/event_listener.rb
+++ b/lib/esse/cli/event_listener.rb
@@ -95,6 +95,13 @@ module Esse
         end
         print_message(stats.join(', ') + '.')
       end
+
+      def elasticsearch_reindex(event)
+        print_message '[%<runtime>s] Reindex from %<from>s to %<to>s successfuly completed',
+          from: colorize(event[:request].dig(:body, :source, :index), :bold),
+          to: colorize(event[:request].dig(:body, :dest, :index), :bold),
+          runtime: formatted_runtime(event[:runtime])
+      end
     end
   end
 end

--- a/lib/esse/cli/index.rb
+++ b/lib/esse/cli/index.rb
@@ -16,15 +16,17 @@ module Esse
       DESC
       option :suffix, type: :string, default: nil, aliases: '-s', desc: 'Suffix to append to index name'
       option :import, type: :boolean, default: true, desc: 'Import documents before point alias to the new index'
+      option :reindex, type: :boolean, default: false, desc: 'Use _reindex API to import documents from the old index to the new index'
       option :optimize, type: :boolean, default: true, desc: 'Optimize index before import documents by disabling refresh_interval and setting number_of_replicas to 0'
       option :settings, type: :hash, default: nil, desc: 'List of settings to pass to the index class. Example: --settings=refresh_interval:1s,number_of_replicas:0'
       def reset(*index_classes)
         require_relative 'index/reset'
         opts = HashUtils.deep_transform_keys(options.to_h, &:to_sym)
+        if opts[:import] && opts[:reindex]
+          raise ArgumentError, 'You cannot use --import and --reindex together'
+        end
         Reset.new(indices: index_classes, **opts).run
       end
-
-      # @TODO Add reindex task to create a new index and import documents from the old index using _reindex API
 
       desc 'create *INDEX_CLASSES', 'Creates indices for the given classes'
       long_desc <<-DESC

--- a/lib/esse/events.rb
+++ b/lib/esse/events.rb
@@ -56,5 +56,6 @@ module Esse
     register_event 'elasticsearch.exist'
     register_event 'elasticsearch.count'
     register_event 'elasticsearch.get'
+    register_event 'elasticsearch.reindex'
   end
 end

--- a/lib/esse/transport/indices.rb
+++ b/lib/esse/transport/indices.rb
@@ -185,6 +185,31 @@ module Esse
           payload[:response] = coerce_exception { client.indices.put_settings(**opts) }
         end
       end
+
+      # Allows to copy documents from one index to another, optionally filtering the source
+      # documents by a query, changing the destination index settings, or fetching the
+      # documents from a remote cluster.
+      #
+      # @option arguments [Boolean] :refresh Should the affected indexes be refreshed?
+      # @option arguments [Time] :timeout Time each individual bulk request should wait for shards that are unavailable.
+      # @option arguments [String] :wait_for_active_shards Sets the number of shard copies that must be active before proceeding with the reindex operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)
+      # @option arguments [Boolean] :wait_for_completion Should the request should block until the reindex is complete.
+      # @option arguments [Number] :requests_per_second The throttle to set on this request in sub-requests per second. -1 means no throttle.
+      # @option arguments [Time] :scroll Control how long to keep the search context alive
+      # @option arguments [Number|string] :slices The number of slices this task should be divided into. Defaults to 1, meaning the task isn't sliced into subtasks. Can be set to `auto`.
+      # @option arguments [Number] :max_docs Maximum number of documents to process (default: all documents)
+      # @option arguments [Hash] :headers Custom HTTP headers
+      # @option arguments [Hash] :body The search definition using the Query DSL and the prototype for the index request. (*Required*)
+      #
+      # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-reindex.html
+      def reindex(body:, **options)
+        throw_error_when_readonly!
+
+        Esse::Events.instrument('elasticsearch.reindex') do |payload|
+          payload[:request] = opts = options.merge(body: body)
+          payload[:response] = coerce_exception { client.reindex(**opts) }
+        end
+      end
     end
 
     include InstanceMethods

--- a/spec/esse/cli/event_listener_spec.rb
+++ b/spec/esse/cli/event_listener_spec.rb
@@ -222,6 +222,36 @@ RSpec.describe Esse::CLI::EventListener do
     end
   end
 
+  describe '.elasticsearch_reindex' do
+    subject do
+      described_class['elasticsearch.reindex'].call(event)
+    end
+
+    let(:event_id) { 'elasticsearch.reindex' }
+
+    let(:event) do
+      Esse::Events::Event.new(event_id, payload)
+    end
+
+    let(:payload) do
+      {
+        runtime: 1.32,
+        request: {
+          body: {
+            source: { index: 'source_index' },
+            dest: { index: 'dest_index' },
+          }
+        }
+      }
+    end
+
+    it 'prints message' do
+      expect { subject }.to output(<<~MSG).to_stdout
+        [#{formatted_runtime(1.32)}] Reindex from #{colorize('source_index', :bold)} to #{colorize('dest_index', :bold)} successfuly completed
+      MSG
+    end
+  end
+
   def colorize(*args)
     Esse::Output.colorize(*args)
   end

--- a/spec/esse/integrations/elasticsearch-5/transport/reindex_spec.rb
+++ b/spec/esse/integrations/elasticsearch-5/transport/reindex_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'support/shared_examples/transport_reindex'
+
+stack_describe 'elasticsearch', '5.x', Esse::Transport, '#reindex' do
+  include_examples 'transport#reindex'
+end

--- a/spec/esse/integrations/elasticsearch-6/transport/reindex_spec.rb
+++ b/spec/esse/integrations/elasticsearch-6/transport/reindex_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'support/shared_examples/transport_reindex'
+
+stack_describe 'elasticsearch', '6.x', Esse::Transport, '#reindex' do
+  include_examples 'transport#reindex'
+end

--- a/spec/esse/integrations/elasticsearch-7/transport/reindex_spec.rb
+++ b/spec/esse/integrations/elasticsearch-7/transport/reindex_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'support/shared_examples/transport_reindex'
+
+stack_describe 'elasticsearch', '7.x', Esse::Transport, '#reindex' do
+  include_examples 'transport#reindex'
+end

--- a/spec/esse/integrations/elasticsearch-8/transport/reindex_spec.rb
+++ b/spec/esse/integrations/elasticsearch-8/transport/reindex_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'support/shared_examples/transport_reindex'
+
+stack_describe 'elasticsearch', '8.x', Esse::Transport, '#reindex' do
+  include_examples 'transport#reindex'
+end

--- a/spec/support/shared_examples/transport_reindex.rb
+++ b/spec/support/shared_examples/transport_reindex.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'transport#reindex' do
+  let(:body) do
+    {
+      settings: {
+        index: {
+          number_of_shards: 1,
+          number_of_replicas: 0
+        }
+      }
+    }
+  end
+
+  it 'raises an Esse::Transport::ReadonlyClusterError exception when the cluster is readonly' do
+    es_client do |client, _conf, cluster|
+      cluster.warm_up!
+      expect(client).not_to receive(:perform_request)
+      cluster.readonly = true
+      expect {
+        cluster.api.reindex(body: { source: { index: "#{cluster.index_prefix}_ro_from" }, dest: { index: "#{cluster.index_prefix}_ro_to" } })
+      }.to raise_error(Esse::Transport::ReadonlyClusterError)
+    end
+  end
+
+  it 'raises an #<Esse::Transport::NotFoundError exception when the source index does not exist' do
+    es_client do |_client, _conf, cluster|
+      expect {
+        cluster.api.reindex(body: { source: { index: "#{cluster.index_prefix}_non_existent_index" }, dest: { index: "#{cluster.index_prefix}_to" } })
+      }.to raise_error(Esse::Transport::NotFoundError)
+    end
+  end
+
+  context 'when the source index exists' do
+    it 'reindexes the source index to the destination index' do
+      es_client do |client, _conf, cluster|
+        source_index = "#{cluster.index_prefix}_reindex_from"
+        dest_index = "#{cluster.index_prefix}_reindex_to"
+        cluster.api.create_index(index: source_index, body: body)
+        cluster.api.create_index(index: dest_index, body: body)
+        cluster.api.index(index: source_index, id: 1, body: { title: 'foo' }, refresh: true)
+
+        resp = nil
+        expect {
+          resp = cluster.api.reindex(body: { source: { index: source_index }, dest: { index: dest_index } }, refresh: true)
+        }.not_to raise_error
+        expect(resp['total']).to eq(1)
+
+        resp = cluster.api.get(index: dest_index, id: 1, _source: false)
+        expect(resp['found']).to eq(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
When reseting index using `reindex: true` it should copy data from previous index to the new one using the [reindex](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/docs-reindex.html) API.

It is useful when we are updating mapping and does not want to load everything from collection.