### PR TITLE
Import preloading lazy attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 - 2024-08-16
+* Rename lazy_update_document_attributes to update_lazy_attributes
+* Rename eager_include_document_attributes to eager_load_lazy_attributes
 ## 0.3.6 - 2024-08-07
 * Esse::LazyDocumentHeader#to_doc return `Esse::LazyDocumentHeader::Document` instance to properly separate context metadata from document source
 * Add `.collection_class` method to the `Esse::Repository` class to let external plugins and extensions to access it instead of read @collection_proc variable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## 0.4.0 - 2024-08-16
 * Rename lazy_update_document_attributes to update_lazy_attributes
 * Rename eager_include_document_attributes to eager_load_lazy_attributes
+* Add preload_lazy_attributes option to the import in order to fetch the lazy attributes in a single query before bulk indexing
+
 ## 0.3.6 - 2024-08-07
 * Esse::LazyDocumentHeader#to_doc return `Esse::LazyDocumentHeader::Document` instance to properly separate context metadata from document source
 * Add `.collection_class` method to the `Esse::Repository` class to let external plugins and extensions to access it instead of read @collection_proc variable

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    esse (0.3.6)
+    esse (0.4.0.rc1)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-1.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-1.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.3.6)
+    esse (0.4.0.rc1)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-2.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-2.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.3.6)
+    esse (0.4.0.rc1)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-5.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-5.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.3.6)
+    esse (0.4.0.rc1)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-6.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-6.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.3.6)
+    esse (0.4.0.rc1)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-7.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-7.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.3.6)
+    esse (0.4.0.rc1)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-8.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-8.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.3.6)
+    esse (0.4.0.rc1)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.opensearch-1.x.lock
+++ b/gemfiles/Gemfile.opensearch-1.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.3.6)
+    esse (0.4.0.rc1)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.opensearch-2.x.lock
+++ b/gemfiles/Gemfile.opensearch-2.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.3.6)
+    esse (0.4.0.rc1)
       multi_json
       thor (>= 0.19)
 

--- a/lib/esse/cli/index.rb
+++ b/lib/esse/cli/index.rb
@@ -97,18 +97,17 @@ module Esse
       option :suffix, type: :string, default: nil, aliases: '-s', desc: 'Suffix to append to index name'
       option :context, type: :hash, default: {}, required: true, desc: 'List of options to pass to the index class'
       option :repo, type: :string, default: nil, alias: '-r', desc: 'Repository to use for import'
-      option :eager_include_document_attributes, type: :string, default: nil, desc: 'Comma separated list of lazy document attributes to include to the bulk index request. Or pass `true` to include all lazy attributes'
-      option :lazy_update_document_attributes, type: :string, default: nil, desc: 'Comma separated list of lazy document attributes to bulk update after the bulk index request Or pass `true` to include all lazy attributes'
+      option :preload_lazy_attributes, type: :string, default: nil, desc: 'Command separated list of lazy document attributes to preload using search API before the bulk import. Or pass `true` to preload all lazy attributes'
+      option :eager_load_lazy_attributes, type: :string, default: nil, desc: 'Comma separated list of lazy document attributes to include to the bulk index request. Or pass `true` to include all lazy attributes'
+      option :update_lazy_attributes, type: :string, default: nil, desc: 'Comma separated list of lazy document attributes to bulk update after the bulk index request Or pass `true` to include all lazy attributes'
+
       def import(*index_classes)
         require_relative 'index/import'
         opts = HashUtils.deep_transform_keys(options.to_h, &:to_sym)
-        opts.delete(:lazy_update_document_attributes) if opts[:lazy_update_document_attributes] == 'false'
-        opts.delete(:eager_include_document_attributes) if opts[:eager_include_document_attributes] == 'false'
-        if (val = opts[:eager_include_document_attributes])
-          opts[:eager_include_document_attributes] = (val == 'true') ? true : val.split(',')
-        end
-        if (val = opts[:lazy_update_document_attributes])
-          opts[:lazy_update_document_attributes] = (val == 'true') ? true : val.split(',')
+        %i[preload_lazy_attributes eager_load_lazy_attributes update_lazy_attributes].each do |key|
+          if (val = opts.delete(key)) && val != 'false'
+            opts[key] = (val == 'true') ? true : val.split(',')
+          end
         end
         Import.new(indices: index_classes, **opts).run
       end

--- a/lib/esse/document.rb
+++ b/lib/esse/document.rb
@@ -115,8 +115,6 @@ module Esse
       instance_variable_set(:@__mutated_source__, nil)
     end
 
-    protected
-
     def mutated_source
       return source unless @__mutations__
 

--- a/lib/esse/index/documents.rb
+++ b/lib/esse/index/documents.rb
@@ -209,6 +209,10 @@ module Esse
         repo_types = repo_hash.keys if repo_types.empty?
         count = 0
 
+        # Backward compatibility while I change plugins using it
+        update_lazy_attributes = options.delete(:lazy_update_document_attributes) if options.key?(:lazy_update_document_attributes)
+        eager_load_lazy_attributes = options.delete(:eager_include_document_attributes) if options.key?(:eager_include_document_attributes)
+
         repo_hash.slice(*repo_types).each do |repo_name, repo|
           # Elasticsearch 6.x and older have multiple types per index.
           # This gem supports multiple types per index for backward compatibility, but we recommend to update

--- a/lib/esse/index/documents.rb
+++ b/lib/esse/index/documents.rb
@@ -199,14 +199,14 @@ module Esse
       # @option [Hash] :context The collection context. This value will be passed as argument to the collection
       #   May be SQL condition or any other filter you have defined on the collection.
       # @return [Numeric] The number of documents imported
-      def import(*repo_types, context: {}, eager_include_document_attributes: false, lazy_update_document_attributes: false, suffix: nil, **options)
+      def import(*repo_types, context: {}, eager_load_lazy_attributes: false, update_lazy_attributes: false, preload_lazy_attributes: false, suffix: nil, **options)
         repo_types = repo_hash.keys if repo_types.empty?
         count = 0
 
         repo_hash.slice(*repo_types).each do |repo_name, repo|
           doc_attrs = {eager: [], lazy: []}
-          doc_attrs[:eager] = repo.lazy_document_attribute_names(eager_include_document_attributes)
-          doc_attrs[:lazy] = repo.lazy_document_attribute_names(lazy_update_document_attributes)
+          doc_attrs[:eager] = repo.lazy_document_attribute_names(eager_load_lazy_attributes)
+          doc_attrs[:lazy] = repo.lazy_document_attribute_names(update_lazy_attributes)
           doc_attrs[:lazy] -= doc_attrs[:eager]
 
           context ||= {}

--- a/lib/esse/version.rb
+++ b/lib/esse/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Esse
-  VERSION = '0.3.6'
+  VERSION = '0.4.0.rc1'
 end

--- a/spec/esse/cli/index/import_spec.rb
+++ b/spec/esse/cli/index/import_spec.rb
@@ -58,44 +58,59 @@ RSpec.describe Esse::CLI::Index, type: :cli do
         cli_exec(%w[index import CountiesIndex CitiesIndex])
       end
 
-      it 'allows --eager-include-document-attributes as a comma separated list' do
-        expect(CountiesIndex).to receive(:import).with(eager_include_document_attributes: %w[foo bar], context: {}).and_return(true)
-        cli_exec(%w[index import CountiesIndex --eager-include-document-attributes=foo,bar])
+      it 'allows --eager-load-lazy-attributes as a comma separated list' do
+        expect(CountiesIndex).to receive(:import).with(eager_load_lazy_attributes: %w[foo bar], context: {}).and_return(true)
+        cli_exec(%w[index import CountiesIndex --eager-load-lazy-attributes=foo,bar])
       end
 
-      it 'allows --lazy-update-document-attributes as a single value' do
-        expect(CountiesIndex).to receive(:import).with(lazy_update_document_attributes: %w[foo], context: {}).and_return(true)
-        cli_exec(%w[index import CountiesIndex --lazy-update-document-attributes=foo])
+      it 'allows --update-lazy-attributes as a single value' do
+        expect(CountiesIndex).to receive(:import).with(update_lazy_attributes: %w[foo], context: {}).and_return(true)
+        cli_exec(%w[index import CountiesIndex --update-lazy-attributes=foo])
       end
 
-      it 'allows --lazy-update-document-attributes as true' do
-        expect(CountiesIndex).to receive(:import).with(lazy_update_document_attributes: true, context: {}).and_return(true)
-        cli_exec(%w[index import CountiesIndex --lazy-update-document-attributes=true])
+      it 'allows --update-lazy-attributes as true' do
+        expect(CountiesIndex).to receive(:import).with(update_lazy_attributes: true, context: {}).and_return(true)
+        cli_exec(%w[index import CountiesIndex --update-lazy-attributes=true])
       end
 
-      it 'allows --lazy-update-document-attributes as false' do
+      it 'allows --update-lazy-attributes as false' do
         expect(CountiesIndex).to receive(:import).with(context: {}).and_return(true)
-        cli_exec(%w[index import CountiesIndex --lazy-update-document-attributes=false])
+        cli_exec(%w[index import CountiesIndex --update-lazy-attributes=false])
       end
 
-      it 'allows --lazy-update-document-attributes as a comma separated list' do
-        expect(CountiesIndex).to receive(:import).with(lazy_update_document_attributes: %w[foo bar], context: {}).and_return(true)
-        cli_exec(%w[index import CountiesIndex --lazy-update-document-attributes=foo,bar])
+      it 'allows --update-lazy-attributes as a comma separated list' do
+        expect(CountiesIndex).to receive(:import).with(update_lazy_attributes: %w[foo bar], context: {}).and_return(true)
+        cli_exec(%w[index import CountiesIndex --update-lazy-attributes=foo,bar])
       end
 
-      it 'allows --lazy-update-document-attributes as a single value' do
-        expect(CountiesIndex).to receive(:import).with(lazy_update_document_attributes: %w[foo], context: {}).and_return(true)
-        cli_exec(%w[index import CountiesIndex --lazy-update-document-attributes=foo])
+      it 'allows --update-lazy-attributes as a single value' do
+        expect(CountiesIndex).to receive(:import).with(update_lazy_attributes: %w[foo], context: {}).and_return(true)
+        cli_exec(%w[index import CountiesIndex --update-lazy-attributes=foo])
       end
 
-      it 'allows --lazy-update-document-attributes as true' do
-        expect(CountiesIndex).to receive(:import).with(lazy_update_document_attributes: true, context: {}).and_return(true)
-        cli_exec(%w[index import CountiesIndex --lazy-update-document-attributes=true])
+      it 'allows --update-lazy-attributes as true' do
+        expect(CountiesIndex).to receive(:import).with(update_lazy_attributes: true, context: {}).and_return(true)
+        cli_exec(%w[index import CountiesIndex --update-lazy-attributes=true])
       end
 
-      it 'allows --lazy-update-document-attributes as false' do
+      it 'allows --update-lazy-attributes as false' do
         expect(CountiesIndex).to receive(:import).with(context: {}).and_return(true)
-        cli_exec(%w[index import CountiesIndex --lazy-update-document-attributes=false])
+        cli_exec(%w[index import CountiesIndex --update-lazy-attributes=false])
+      end
+
+      it 'allows --preload-lazy-attributes as a comma separated list' do
+        expect(CountiesIndex).to receive(:import).with(preload_lazy_attributes: %w[foo bar], context: {}).and_return(true)
+        cli_exec(%w[index import CountiesIndex --preload-lazy-attributes=foo,bar])
+      end
+
+      it 'allows --preload-lazy-attributes as true' do
+        expect(CountiesIndex).to receive(:import).with(preload_lazy_attributes: true, context: {}).and_return(true)
+        cli_exec(%w[index import CountiesIndex --preload-lazy-attributes=true])
+      end
+
+      it 'allows --preload-lazy-attributes as false' do
+        expect(CountiesIndex).to receive(:import).with(context: {}).and_return(true)
+        cli_exec(%w[index import CountiesIndex --preload-lazy-attributes=false])
       end
     end
   end

--- a/spec/support/shared_examples/repository_documents_import.rb
+++ b/spec/support/shared_examples/repository_documents_import.rb
@@ -63,14 +63,14 @@ RSpec.shared_examples 'repository.import' do
     end
   end
 
-  context 'when the lazy_update_document_attributes is set' do
+  context 'when the update_lazy_attributes is set' do
     it 'indexes the data and bulk updates all the lazy document attributes' do
       es_client do |client, _conf, cluster|
         GeosIndex.create_index(alias: true)
 
         resp = nil
         expect {
-          resp = GeosIndex::County.import(lazy_update_document_attributes: true)
+          resp = GeosIndex::County.import(update_lazy_attributes: true)
         }.not_to raise_error
         expect(resp).to eq(total_counties)
 
@@ -89,7 +89,7 @@ RSpec.shared_examples 'repository.import' do
 
         resp = nil
         expect {
-          resp = GeosIndex::County.import(lazy_update_document_attributes: %i[country])
+          resp = GeosIndex::County.import(update_lazy_attributes: %i[country])
         }.not_to raise_error
         expect(resp).to eq(total_counties)
 
@@ -103,14 +103,14 @@ RSpec.shared_examples 'repository.import' do
     end
   end
 
-  context 'when the eager_include_document_attributes is set' do
+  context 'when the eager_load_lazy_attributes is set' do
     it 'indexes the data and bulk updates all the eager document attributes' do
       es_client do |client, _conf, cluster|
         GeosIndex.create_index(alias: true)
 
         resp = nil
         expect {
-          resp = GeosIndex::County.import(eager_include_document_attributes: true)
+          resp = GeosIndex::County.import(eager_load_lazy_attributes: true)
         }.not_to raise_error
         expect(resp).to eq(total_counties)
 
@@ -129,7 +129,7 @@ RSpec.shared_examples 'repository.import' do
 
         resp = nil
         expect {
-          resp = GeosIndex::County.import(eager_include_document_attributes: %i[country])
+          resp = GeosIndex::County.import(eager_load_lazy_attributes: %i[country])
         }.not_to raise_error
         expect(resp).to eq(total_counties)
 
@@ -174,7 +174,7 @@ RSpec.shared_examples 'repository.import' do
 
         resp = nil
         expect {
-          resp = StoriesIndex::Story.import(lazy_update_document_attributes: %i[tags])
+          resp = StoriesIndex::Story.import(update_lazy_attributes: %i[tags])
         }.not_to raise_error
         expect(resp).to eq(stories.size)
 


### PR DESCRIPTION
When passing `preload_lazy_attributes` to import, it will first fetch the document attributes and add it to the index bulk payload to avoid lost data.