### PR TITLE
feat: add update_lazy_attributes command to CLI

### DIFF
--- a/lib/esse/cli/index.rb
+++ b/lib/esse/cli/index.rb
@@ -59,7 +59,7 @@ module Esse
       DESC
       option :suffix, type: :string, default: nil, aliases: '-s', desc: 'Suffix to append to index name'
       option :alias, type: :boolean, default: false, aliases: '-a', desc: 'Update alias after create index'
-      option :settings, type: :hash, default: nil, desc: 'List of settings to pass to the index class. Example: --settings=index.refresh_interval:-1,index.number_of_replicas:0'
+      option :settings, type: :hash, default: nil, desc: 'List of settings to pass to the index class. Example: --settings=index.refresh_interval:-1 index.number_of_replicas:0'
       def create(*index_classes)
         require_relative 'index/create'
         opts = HashUtils.deep_transform_keys(options.to_h, &:to_sym)
@@ -86,7 +86,7 @@ module Esse
       desc 'update_settings *INDEX_CLASS', 'Closes the index for read/write operations, updates the index settings, and open it again'
       option :suffix, type: :string, default: nil, aliases: '-s', desc: 'Suffix to append to index name'
       option :type, type: :string, default: nil, aliases: '-t', desc: 'Document Type to update mapping for'
-      option :settings, type: :hash, default: nil, desc: 'List of settings to pass to the index class. Example: --settings=index.refresh_interval:-1,index.number_of_replicas:0'
+      option :settings, type: :hash, default: nil, desc: 'List of settings to pass to the index class. Example: --settings=index.refresh_interval:-1 index.number_of_replicas:0'
       def update_settings(*index_classes)
         require_relative 'index/update_settings'
         opts = HashUtils.deep_transform_keys(options.to_h, &:to_sym)
@@ -132,6 +132,17 @@ module Esse
           end
         end
         Import.new(indices: index_classes, **opts).run
+      end
+
+      desc "update_lazy_attributes INDEX_CLASS", "Async update lazy attributes for the given index"
+      option :repo, type: :string, default: nil, alias: "-r", desc: "Repository to use for import"
+      option :suffix, type: :string, default: nil, aliases: "-s", desc: "Suffix to append to index name"
+      option :context, type: :hash, default: {}, required: true, desc: "List of options to pass to the index class"
+      option :bulk_options, type: :hash, default: nil, desc: 'List of options to pass to the bulk update request. Example: --bulk-options=timeout:30s refresh:true retry_on_conflict:3'
+      def update_lazy_attributes(index_class, *attributes)
+        require_relative "index/update_lazy_attributes"
+        opts = HashUtils.deep_transform_keys(options.to_h, &:to_sym)
+        UpdateLazyAttributes.new(indices: [index_class], attributes: attributes, **opts).run
       end
     end
   end

--- a/lib/esse/cli/index/update_lazy_attributes.rb
+++ b/lib/esse/cli/index/update_lazy_attributes.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require_relative 'base_operation'
+
+module Esse
+  module CLI
+    class Index::UpdateLazyAttributes < Index::BaseOperation
+      attr_reader :attributes
+
+      def initialize(indices:, attributes: nil, **options)
+        super(indices: indices, **options)
+        @attributes = Array(attributes)
+      end
+
+      def run
+        validate_options!
+        indices.each do |index|
+          repos = if (repo = @options[:repo])
+            [index.repo(repo)]
+          else
+            index.repo_hash.values
+          end
+
+          repos.each do |repo|
+            attrs = repo_attributes(repo)
+            next unless attrs.any?
+
+            repo.send(:each_batch_ids, **context_options) do |ids|
+              attrs.each do |attribute|
+                repo.update_documents_attribute(attribute, ids, bulk_options)
+              end
+            end
+          end
+        end
+      end
+
+      private
+
+      def bulk_options
+        @bulk_options ||= HashUtils.deep_transform_keys(@options[:bulk_options].to_h, &:to_sym).transform_values do |value|
+          value.is_a?(String) ? Hstring.new(value).coerce_type : value
+        end
+      end
+
+      def context_options
+        @context_options ||= HashUtils.deep_transform_keys(@options[:context].to_h, &:to_sym).transform_values do |value|
+          value.is_a?(String) ? Hstring.new(value).coerce_type : value
+        end
+      end
+
+      def validate_options!
+        validate_indices_option!
+      end
+
+      def repo_attributes(repo)
+        return repo.lazy_document_attribute_names(true) if attributes.empty?
+
+        repo.lazy_document_attribute_names(attributes)
+      end
+    end
+  end
+end

--- a/lib/esse/cli/index/update_lazy_attributes.rb
+++ b/lib/esse/cli/index/update_lazy_attributes.rb
@@ -37,13 +37,13 @@ module Esse
       private
 
       def bulk_options
-        @bulk_options ||= HashUtils.deep_transform_keys(@options[:bulk_options].to_h, &:to_sym).transform_values do |value|
+        @bulk_options ||= (@options[:bulk_options] || {}).transform_values do |value|
           value.is_a?(String) ? Hstring.new(value).coerce_type : value
         end
       end
 
       def context_options
-        @context_options ||= HashUtils.deep_transform_keys(@options[:context].to_h, &:to_sym).transform_values do |value|
+        @context_options ||= (@options[:context] || {}).transform_values do |value|
           value.is_a?(String) ? Hstring.new(value).coerce_type : value
         end
       end

--- a/lib/esse/collection.rb
+++ b/lib/esse/collection.rb
@@ -14,5 +14,11 @@ module Esse
     def each
       raise NotImplementedError, 'Override this method to iterate over the collection'
     end
+
+    # @yield [<Array>] A batch of document IDs to be processed.
+    # @abstract Override this method to yield each chunk of document IDs
+    def each_batch_ids
+      raise NotImplementedError, 'Override this method to iterate over the collection in batches of IDs'
+    end
   end
 end

--- a/lib/esse/primitives/hstring.rb
+++ b/lib/esse/primitives/hstring.rb
@@ -82,5 +82,19 @@ module Esse
       @value
     end
     def_conventional :presence!
+
+    def coerce_type
+      if @value =~ /\A-?\d+\z/
+        return @value.to_i
+      elsif @value =~ /\A-?\d+\.\d+\z/
+        return @value.to_f
+      elsif @value == 'true'
+        return true
+      elsif @value == 'false'
+        return false
+      end
+
+      @value
+    end
   end
 end

--- a/lib/esse/repository/documents.rb
+++ b/lib/esse/repository/documents.rb
@@ -10,6 +10,7 @@ module Esse
       def update_documents_attribute(name, ids_or_doc_headers = [], kwargs = {})
         batch = documents_for_lazy_attribute(name, ids_or_doc_headers)
         return if batch.empty?
+
         kwargs = kwargs.transform_keys(&:to_sym)
 
         if kwargs.delete(:index_on_missing) { true }

--- a/lib/esse/repository/object_document_mapper.rb
+++ b/lib/esse/repository/object_document_mapper.rb
@@ -220,7 +220,7 @@ module Esse
         if @collection_proc.is_a?(Class) && @collection_proc.method_defined?(:each_batch_ids)
           @collection_proc.new(*args, **kwargs).each_batch_ids(&block)
         else
-          Esse.logger.warn(<<~MSG)
+          Kernel.warn(<<~MSG)
             The public `#each_batch_ids' method is not available for the collection defined in the #{repo_name} index.
 
             The `#each' method will be used instead, which may lead to performance degradation because it serializes the entire document

--- a/lib/esse/repository/object_document_mapper.rb
+++ b/lib/esse/repository/object_document_mapper.rb
@@ -200,6 +200,53 @@ module Esse
       rescue LocalJumpError
         raise(SyntaxError, 'block must be explicitly declared in the collection definition')
       end
+
+      # Used to fetch batches of ids from the collection that implement the `each_batch_ids` method.
+      #
+      # @param [Hash] kwargs The context
+      # @yield [Array] A batch of document IDs to be processed.
+      # @raise [NotImplementedError] if the collection does not implement the `each_batch_ids` method.
+      # @raise [NotImplementedError] if the collection is not defined.
+      # @return [void]
+      # @example
+      #   each_batch_ids(active: true) do |ids|
+      #     puts ids.size
+      #   end
+      def each_batch_ids(*args, **kwargs, &block)
+        if @collection_proc.nil?
+          raise NotImplementedError, format('there is no %<t>p collection defined for the %<k>p index', t: repo_name, k: index.to_s)
+        end
+
+        if @collection_proc.is_a?(Class) && @collection_proc.method_defined?(:each_batch_ids)
+          @collection_proc.new(*args, **kwargs).each_batch_ids(&block)
+        else
+          Esse.logger.warn(<<~MSG)
+            The public `#each_batch_ids' method is not available for the collection defined in the #{repo_name} index.
+
+            The `#each' method will be used instead, which may lead to performance degradation because it serializes the entire document
+            to only obtain the IDs. Consider implementing a public `#each_batch_ids' method in your collection class for better performance.
+
+            Example implementation taking into account you are dealing with an ActiveRecord model:
+              class UserCollection < Esse::Collection
+                # ....
+
+                def each_batch_ids
+                  user_query.except(:includes, :preload, :eager_load).in_batches do |batch|
+                    yield batch.pluck(:id)
+                  end
+                end
+              end
+          MSG
+          each_batch(*args, **kwargs) do |*args|
+            batch, collection_context = args
+            collection_context ||= {}
+            ids = [*batch].map { |entry| serialize(entry, **collection_context)&.id }.compact
+            block.call(ids)
+          end
+        end
+      rescue LocalJumpError
+        raise(SyntaxError, 'block must be explicitly declared in the collection definition')
+      end
     end
 
     extend ClassMethods

--- a/spec/esse/cli/index/update_lazy_attributes_spec.rb
+++ b/spec/esse/cli/index/update_lazy_attributes_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'support/cli_helpers'
+
+RSpec.describe Esse::CLI::Index, type: :cli do
+  describe "#update_lazy_attributes" do
+    let(:index_collection_class) do
+      Class.new(Esse::Collection) do
+        def each_batch_ids
+          yield([1, 2, 3])
+        end
+      end
+    end
+
+    after do
+      reset_config!
+    end
+
+    context "when passing undefined or invalid index name" do
+      it "raises an error if given argument is not a valid index class" do
+        expect {
+          cli_exec(%w[index update_lazy_attributes Esse::Config])
+        }.to raise_error(Esse::CLI::InvalidOption, /Esse::Config must be a subclass of Esse::Index/)
+      end
+
+      it "raises an error if given argument is not defined" do
+        expect {
+          cli_exec(%w[index update_lazy_attributes NotDefinedIndexName])
+        }.to raise_error(Esse::CLI::InvalidOption, /Unrecognized index class: "NotDefinedIndexName"/)
+      end
+    end
+
+
+    context "when passing a valid index with single repository" do
+      before do
+        collection_class = index_collection_class
+        stub_index(:cities) do
+          repository :city do
+            collection collection_class
+            lazy_document_attribute :total_events do |docs|
+              docs.map { |doc| [doc.id, 10] }.to_h
+            end
+            lazy_document_attribute :total_venues do |docs|
+              docs.map { |doc| [doc.id, 20] }.to_h
+            end
+          end
+        end
+      end
+
+      it "calls the update_documents_attribute method for each lazy attribute" do
+        expect(CitiesIndex::City).to receive(:update_documents_attribute).with(:total_events, [1, 2, 3], {}).and_return(:ok)
+        expect(CitiesIndex::City).to receive(:update_documents_attribute).with(:total_venues, [1, 2, 3], {}).and_return(:ok)
+
+        cli_exec(%w[index update_lazy_attributes CitiesIndex])
+      end
+
+      it "calls the update_documents_attribute method with bulk options" do
+        expect(CitiesIndex::City).to receive(:update_documents_attribute).with(:total_events, [1, 2, 3], refresh: true, retry_on_conflict: 3, timeout: "30s").and_return(:ok)
+        expect(CitiesIndex::City).to receive(:update_documents_attribute).with(:total_venues, [1, 2, 3], refresh: true, retry_on_conflict: 3, timeout: "30s").and_return(:ok)
+
+        cli_exec(%w[index update_lazy_attributes CitiesIndex --bulk-options=timeout:30s refresh:true retry_on_conflict:3])
+      end
+
+      it "calls the update_documents_attribute method with context options" do
+        expect(CitiesIndex::City).to receive(:each_batch_ids).once.with(active: true).and_call_original
+        expect(CitiesIndex::City).to receive(:update_documents_attribute).with(:total_events, [1, 2, 3], {}).and_return(:ok)
+        expect(CitiesIndex::City).to receive(:update_documents_attribute).with(:total_venues, [1, 2, 3], {}).and_return(:ok)
+
+        cli_exec(%w[index update_lazy_attributes CitiesIndex --context=active:true])
+      end
+
+      it "allows to specify lazy attributes to update" do
+        expect(CitiesIndex::City).to receive(:update_documents_attribute).with(:total_events, [1, 2, 3], {}).and_return(:ok)
+        expect(CitiesIndex::City).not_to receive(:update_documents_attribute).with(:total_venues, [1, 2, 3], {})
+
+        cli_exec(%w[index update_lazy_attributes CitiesIndex total_events])
+      end
+
+      it "allows to specify index repository" do
+        expect(CitiesIndex::City).to receive(:update_documents_attribute).with(:total_events, [1, 2, 3], {}).and_return(:ok)
+        expect(CitiesIndex::City).not_to receive(:update_documents_attribute).with(:total_venues, [1, 2, 3], {})
+
+        cli_exec(%w[index update_lazy_attributes CitiesIndex --repo=city total_events])
+      end
+    end
+  end
+end

--- a/spec/esse/cli/index/update_lazy_attributes_spec.rb
+++ b/spec/esse/cli/index/update_lazy_attributes_spec.rb
@@ -56,8 +56,8 @@ RSpec.describe Esse::CLI::Index, type: :cli do
       end
 
       it "calls the update_documents_attribute method with bulk options" do
-        expect(CitiesIndex::City).to receive(:update_documents_attribute).with(:total_events, [1, 2, 3], refresh: true, retry_on_conflict: 3, timeout: "30s").and_return(:ok)
-        expect(CitiesIndex::City).to receive(:update_documents_attribute).with(:total_venues, [1, 2, 3], refresh: true, retry_on_conflict: 3, timeout: "30s").and_return(:ok)
+        expect(CitiesIndex::City).to receive(:update_documents_attribute).with(:total_events, [1, 2, 3], {refresh: true, retry_on_conflict: 3, timeout: "30s"}).and_return(:ok)
+        expect(CitiesIndex::City).to receive(:update_documents_attribute).with(:total_venues, [1, 2, 3], {refresh: true, retry_on_conflict: 3, timeout: "30s"}).and_return(:ok)
 
         cli_exec(%w[index update_lazy_attributes CitiesIndex --bulk-options=timeout:30s refresh:true retry_on_conflict:3])
       end

--- a/spec/esse/collection_spec.rb
+++ b/spec/esse/collection_spec.rb
@@ -17,4 +17,16 @@ RSpec.describe Esse::Collection do
 
     it { is_expected.to eq options }
   end
+
+  describe '#each' do
+    it 'raises NotImplementedError' do
+      expect { collection.each }.to raise_error(NotImplementedError, 'Override this method to iterate over the collection')
+    end
+  end
+
+  describe '#each_batch_ids' do
+    it 'raises NotImplementedError' do
+      expect { collection.each_batch_ids }.to raise_error(NotImplementedError, 'Override this method to iterate over the collection in batches of IDs')
+    end
+  end
 end

--- a/spec/esse/primitives/hstring_spec.rb
+++ b/spec/esse/primitives/hstring_spec.rb
@@ -135,4 +135,38 @@ RSpec.describe Esse::Hstring do
       it { is_expected.not_to be_an_instance_of(described_class) }
     end
   end
+
+  describe '#coerce_type' do
+    subject { model.coerce_type }
+
+    context 'with an integer string' do
+      let(:arg) { '123' }
+
+      it { is_expected.to eq(123) }
+    end
+
+    context 'with a float string' do
+      let(:arg) { '123.45' }
+
+      it { is_expected.to eq(123.45) }
+    end
+
+    context 'with a true string' do
+      let(:arg) { 'true' }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'with a false string' do
+      let(:arg) { 'false' }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context 'with a non-coercible string' do
+      let(:arg) { 'hello' }
+
+      it { is_expected.to eq('hello') }
+    end
+  end
 end

--- a/spec/esse/repository/collection_spec.rb
+++ b/spec/esse/repository/collection_spec.rb
@@ -197,7 +197,7 @@ RSpec.describe Esse::Repository do
 
       it "warns user for performance degradation and yields serialized ids" do
         o = { active: true }
-        expect(logger).to receive(:warn).with(a_string_matching("The `#each' method will be used instead, which may lead to performance degradation"))
+        expect(Kernel).to receive(:warn).with(a_string_matching("The `#each' method will be used instead, which may lead to performance degradation"))
 
         expect { |b| UsersIndex::User.send(:each_batch_ids, **o, &b) }.to yield_successive_args([1], [2], [3])
       end

--- a/spec/esse/repository/collection_spec.rb
+++ b/spec/esse/repository/collection_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Esse::Repository do
         stub_index(:users) do
           repository :user do
             collection do |**opts, &block|
-              [[1], [2], [3]].each do |batch|
+              [[{id: 1}], [{id: 2}], [{id: 3}]].each do |batch|
                 block.call batch, opts
               end
             end
@@ -109,11 +109,22 @@ RSpec.describe Esse::Repository do
 
       it 'yields each block with arguments' do
         o = { active: true }
-        expect { |b| UsersIndex::User.send(:each_batch, **o, &b) }.to yield_successive_args([[1], o], [[2], o], [[3], o])
+        expect { |b| UsersIndex::User.send(:each_batch, **o, &b) }.to yield_successive_args(
+          [[{id: 1}], o],
+          [[{id: 2}], o],
+          [[{id: 3}], o]
+        )
       end
     end
 
     context 'with a collection class' do
+      let(:ids) { (1..6).to_a }
+      let(:repo) do
+        ids.map do |id|
+          { id: id }
+        end
+      end
+
       before do
         stub_index(:geos) do
           repository :city do
@@ -124,8 +135,94 @@ RSpec.describe Esse::Repository do
 
       it 'yields each block with arguments' do
         f = { active: true }
-        o = { repo: (1..6), batch_size: 2 }.merge(f)
-        expect { |b| GeosIndex::City.send(:each_batch, **o, &b) }.to yield_successive_args([[1, 2], f], [[3, 4], f], [[5, 6], f])
+        o = { repo: repo, batch_size: 2 }.merge(f)
+        expect { |b| GeosIndex::City.send(:each_batch, **o, &b) }.to yield_successive_args(
+          [[{id: 1}, {id: 2}], f],
+          [[{id: 3}, {id: 4}], f],
+          [[{id: 5}, {id: 6}], f]
+        )
+      end
+    end
+  end
+
+  describe '.each_batch_ids' do
+    context 'without the collection definition' do
+      before do
+        stub_index(:users) do
+          repository(:user) {}
+        end
+      end
+
+      specify do
+        expect {
+          UsersIndex::User.send(:each_batch_ids) { |batch| puts batch }
+        }.to raise_error(NotImplementedError, 'there is no "user" collection defined for the "UsersIndex" index')
+      end
+    end
+
+    context 'without collection data' do
+      before do
+        stub_index(:users) do
+          repository :user do
+            collection do
+            end
+          end
+        end
+      end
+
+      it 'does not raise any exception' do
+        expect { |b| UsersIndex::User.send(:each_batch_ids, &b) }.not_to yield_control
+      end
+    end
+
+    context 'with the collection definition' do
+      let(:logger) { instance_double(::Logger) }
+
+      before do
+        stub_index(:users) do
+          repository :user do
+            collection do |**opts, &block|
+              [[{id: 1}], [{id: 2}], [{id: 3}]].each do |batch|
+                block.call batch, opts
+              end
+            end
+
+            document do |hash, **opts|
+              Esse::HashDocument.new(hash)
+            end
+          end
+        end
+        allow(::Esse).to receive(:logger).and_return(logger)
+      end
+
+      it "warns user for performance degradation and yields serialized ids" do
+        o = { active: true }
+        expect(logger).to receive(:warn).with(a_string_matching("The `#each' method will be used instead, which may lead to performance degradation"))
+
+        expect { |b| UsersIndex::User.send(:each_batch_ids, **o, &b) }.to yield_successive_args([1], [2], [3])
+      end
+    end
+
+    context 'with a collection class' do
+      let(:ids) { (1..6).to_a }
+      let(:repo) do
+        ids.map do |id|
+          { id: id, name: "City #{id}", active: true }
+        end
+      end
+
+      before do
+        stub_index(:geos) do
+          repository :city do
+            collection DummyGeosCollection
+          end
+        end
+      end
+
+      it 'yields each block with arguments' do
+        f = { active: true }
+        o = { repo: repo, batch_size: 2 }.merge(f)
+        expect { |b| GeosIndex::City.send(:each_batch_ids, **o, &b) }.to yield_successive_args([1, 2], [3, 4], [5, 6])
       end
     end
   end

--- a/spec/support/collections.rb
+++ b/spec/support/collections.rb
@@ -2,6 +2,7 @@
 
 class DummyGeosCollection
   include Enumerable
+
   BATCH_SIZE = 2
 
   # @param params [Hash] List of parameters
@@ -14,6 +15,15 @@ class DummyGeosCollection
   def each
     @repo.each_slice(@batch_size) do |rows|
       yield(rows, @params)
+    end
+  end
+
+  def each_batch_ids
+    @repo.each_slice(@batch_size) do |rows|
+      ids = rows.map do |row|
+        row.is_a?(Hash) ? row[:id] || row[:_id] || row['id'] || row['_id'] : row
+      end
+      yield(ids)
     end
   end
 end


### PR DESCRIPTION
Add update_lazy_attributes command to the CLI to let update a lazy attributes in batches.

Usage

```bash
esse index update_lazy_attributes UsersIndex events_count
```

The collection of index must implement the `#each_batch_ids` method.

Example:

```ruby
 class UsersIndex::Collections::UserCollection < Esse::Collection
  def initialize(**context)
    @query = User.preload(:profile)
    @query = @query.where(active: true) if context[:active]
  end

  def each_batch_ids
    query.except(:includes, :preload, :eager_load).in_batches do |batch|
      yield batch.pluck(:id)
    end
  end

  protected

  attr_reader :query
end
```