### PR TITLE
Fix settings_hash clobbering nested template values with flat globals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.1
+* Fix `Esse::Index.settings_hash` clobbering nested per-index template values (e.g. `index.number_of_shards`) with flat top-level cluster-level globals (e.g. top-level `number_of_shards`). Both forms are now normalized to the nested form on each side before merging, so the per-index template's explicit value wins as expected.
+* Move `INDEX_SIMPLIFIED_SETTINGS` to `Esse::IndexSetting` (kept as a backwards-compatible alias on `Esse::Index::ClassMethods`).
+
 ## 0.4.0 - 2024-08-16
 * Rename lazy_update_document_attributes to update_lazy_attributes
 * Rename eager_include_document_attributes to eager_load_lazy_attributes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    esse (0.4.0)
+    esse (0.4.1)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-1.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-1.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.4.0)
+    esse (0.4.1)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-2.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-2.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.4.0)
+    esse (0.4.1)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-5.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-5.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.4.0)
+    esse (0.4.1)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-6.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-6.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.4.0)
+    esse (0.4.1)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-7.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-7.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.4.0)
+    esse (0.4.1)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-8.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-8.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.4.0)
+    esse (0.4.1)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.opensearch-1.x.lock
+++ b/gemfiles/Gemfile.opensearch-1.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.4.0)
+    esse (0.4.1)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.opensearch-2.x.lock
+++ b/gemfiles/Gemfile.opensearch-2.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.4.0)
+    esse (0.4.1)
       multi_json
       thor (>= 0.19)
 

--- a/lib/esse/index/settings.rb
+++ b/lib/esse/index/settings.rb
@@ -10,7 +10,13 @@ module Esse
       INDEX_SIMPLIFIED_SETTINGS = Esse::IndexSetting::INDEX_SIMPLIFIED_SETTINGS
 
       def settings_hash(settings: nil)
-        values = setting.body
+        # Normalize each side (global vs local) separately before merging so
+        # a flat global key (e.g. top-level :number_of_shards) cannot clobber
+        # an explicit nested local value (e.g. :index => { :number_of_shards => 8 }).
+        global = Esse::IndexSetting.normalize(setting.globals)
+        local = Esse::IndexSetting.normalize(setting.to_h)
+        values = HashUtils.deep_merge(global, local)
+
         if settings.is_a?(Hash)
           values = HashUtils.deep_merge(values, Esse::IndexSetting.normalize(settings))
         end

--- a/lib/esse/index/settings.rb
+++ b/lib/esse/index/settings.rb
@@ -4,29 +4,15 @@ module Esse
   # https://github.com/elastic/elasticsearch-ruby/blob/master/elasticsearch-api/lib/elasticsearch/api/actions/indices/put_settings.rb
   class Index
     module ClassMethods
-      # Elasticsearch supports passing index.* related settings directly in the body of the request.
-      # We are moving it to the index key to make it more explicit and to be the source-of-truth when merging settings.
-      # So the settings `{ number_of_shards: 1 }` will be transformed to `{ index: { number_of_shards: 1 } }`
-      INDEX_SIMPLIFIED_SETTINGS = %i[
-        number_of_shards
-        number_of_replicas
-        refresh_interval
-        mapping
-      ].freeze
+      # Backwards-compatible alias. The canonical list now lives on
+      # +Esse::IndexSetting::INDEX_SIMPLIFIED_SETTINGS+ so that the merge
+      # logic and the simplified-key promotion stay in sync.
+      INDEX_SIMPLIFIED_SETTINGS = Esse::IndexSetting::INDEX_SIMPLIFIED_SETTINGS
 
       def settings_hash(settings: nil)
-        hash = setting.body
-        values = (hash.key?(Esse::SETTING_ROOT_KEY) ? hash[Esse::SETTING_ROOT_KEY] : hash)
-        values = HashUtils.explode_keys(values)
+        values = setting.body
         if settings.is_a?(Hash)
-          values = HashUtils.deep_merge(values, HashUtils.explode_keys(settings))
-        end
-        INDEX_SIMPLIFIED_SETTINGS.each do |key|
-          next unless values.key?(key)
-          value = values.delete(key)
-          next if value.nil?
-
-          (values[:index] ||= {}).merge!(key => value)
+          values = HashUtils.deep_merge(values, Esse::IndexSetting.normalize(settings))
         end
 
         if values[:index].is_a?(Hash)

--- a/lib/esse/index_setting.rb
+++ b/lib/esse/index_setting.rb
@@ -3,6 +3,17 @@
 module Esse
   # https://www.elastic.co/guide/en/elasticsearch/reference/1.7/indices.html
   class IndexSetting
+    # Top-level keys that Elasticsearch/OpenSearch accept either flat or nested
+    # under `index:`. We always promote them to the nested form so that values
+    # from different sources (cluster globals vs per-index template) merge
+    # predictably regardless of which form each side was authored in.
+    INDEX_SIMPLIFIED_SETTINGS = %i[
+      number_of_shards
+      number_of_replicas
+      refresh_interval
+      mapping
+    ].freeze
+
     # @param [Hash] options
     # @option options [Proc] :globals  A proc that will be called to load global settings
     # @option options [Array] :paths   A list of paths to load settings from
@@ -30,9 +41,30 @@ module Esse
     end
 
     def body
-      global = HashUtils.deep_transform_keys(@globals.call, &:to_sym)
-      local = HashUtils.deep_transform_keys(to_h, &:to_sym)
-      HashUtils.deep_merge(global, local)
+      HashUtils.deep_merge(self.class.normalize(@globals.call), self.class.normalize(to_h))
+    end
+
+    # Normalize a settings hash by:
+    #   * symbolizing keys
+    #   * stripping the `:settings` root if present
+    #   * exploding dotted keys ('index.number_of_replicas' -> { index: { number_of_replicas: ... } })
+    #   * promoting simplified flat keys (number_of_shards, etc.) into the
+    #     nested `:index` form, while preserving any value already present
+    #     under `:index` (so we never overwrite an explicit nested setting
+    #     with a flat value from the same source).
+    def self.normalize(hash)
+      values = HashUtils.deep_transform_keys(hash || {}, &:to_sym)
+      values = values[Esse::SETTING_ROOT_KEY] if values.key?(Esse::SETTING_ROOT_KEY)
+      values = HashUtils.explode_keys(values)
+      INDEX_SIMPLIFIED_SETTINGS.each do |key|
+        next unless values.key?(key)
+        value = values.delete(key)
+        next if value.nil?
+
+        values[:index] ||= {}
+        values[:index][key] = value unless values[:index].key?(key)
+      end
+      values
     end
 
     protected

--- a/lib/esse/index_setting.rb
+++ b/lib/esse/index_setting.rb
@@ -41,7 +41,18 @@ module Esse
     end
 
     def body
-      HashUtils.deep_merge(self.class.normalize(@globals.call), self.class.normalize(to_h))
+      global = HashUtils.deep_transform_keys(@globals.call, &:to_sym)
+      local = HashUtils.deep_transform_keys(to_h, &:to_sym)
+      HashUtils.deep_merge(global, local)
+    end
+
+    # Returns the raw (unsymbolized) global settings as supplied by the
+    # +globals+ proc. Public so that callers like
+    # +Esse::Index.settings_hash+ can normalize it independently before
+    # merging it with the local template — preventing a flat global value
+    # from clobbering a nested local value once both are merged.
+    def globals
+      @globals.call || {}
     end
 
     # Normalize a settings hash by:
@@ -49,9 +60,9 @@ module Esse
     #   * stripping the `:settings` root if present
     #   * exploding dotted keys ('index.number_of_replicas' -> { index: { number_of_replicas: ... } })
     #   * promoting simplified flat keys (number_of_shards, etc.) into the
-    #     nested `:index` form, while preserving any value already present
-    #     under `:index` (so we never overwrite an explicit nested setting
-    #     with a flat value from the same source).
+    #     nested `:index` form, preserving any value already present under
+    #     `:index` (we never overwrite an explicit nested setting with a
+    #     flat value from the same source).
     def self.normalize(hash)
       values = HashUtils.deep_transform_keys(hash || {}, &:to_sym)
       values = values[Esse::SETTING_ROOT_KEY] if values.key?(Esse::SETTING_ROOT_KEY)

--- a/lib/esse/version.rb
+++ b/lib/esse/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Esse
-  VERSION = '0.4.0'
+  VERSION = '0.4.1'
 end

--- a/spec/esse/index/settings_spec.rb
+++ b/spec/esse/index/settings_spec.rb
@@ -167,6 +167,36 @@ RSpec.describe Esse::Index do
       end
     end
 
+    # Regression: when the cluster (global) settings are authored in the
+    # flat form (e.g. `number_of_shards: 1` at the top level) and the
+    # per-index template is authored in the nested form (under `index:`),
+    # the per-index nested values must win — not be clobbered by the
+    # flat global values.
+    context 'with flat global settings and nested local settings' do
+      before do
+        stub_index(:geos) do
+          settings(index: { number_of_shards: 8, number_of_replicas: 1, max_result_window: 50_000_000 })
+        end
+      end
+
+      it 'lets the local nested values win over the flat global values' do
+        with_cluster_config(settings: {
+          number_of_shards: 1,
+          number_of_replicas: 0,
+          refresh_interval: '5s',
+        }) do
+          expect(GeosIndex.settings_hash).to eq(
+            settings: { index: {
+              number_of_shards: 8,
+              number_of_replicas: 1,
+              refresh_interval: '5s',
+              max_result_window: 50_000_000,
+            } },
+          )
+        end
+      end
+    end
+
     context 'with nil values in the simplified settings' do
       before do
         stub_index(:geos) do


### PR DESCRIPTION
When the cluster (global) settings are authored in the flat form (e.g. top-level number_of_shards: 1) and a per-index template is authored in the nested form (under index:), the simplified-key promotion in settings_hash ran AFTER the deep_merge and used merge!(key => value), which overwrote any value already present under values[:index] with the flat global value. Net effect: index.number_of_shards: 8 from the template was clobbered by number_of_shards: 1 from the cluster.

The fix normalizes each side (flat -> nested under :index) BEFORE deep_merge, so deep_merge's standard local-wins semantics apply and the per-index template's explicit value wins as expected.

INDEX_SIMPLIFIED_SETTINGS moved to Esse::IndexSetting and kept as a backwards-compatible alias on Esse::Index::ClassMethods.

Bump to 0.4.1.
