### PR TITLE
Retry bulk import one document per request on 413

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    esse (0.4.1)
+    esse (0.5.0)
       multi_json
       thor (>= 0.19)
 
@@ -24,7 +24,7 @@ GEM
     language_server-protocol (3.17.0.3)
     lint_roller (1.1.0)
     method_source (1.1.0)
-    multi_json (1.15.0)
+    multi_json (1.21.1)
     parallel (1.24.0)
     parser (3.3.3.0)
       ast (~> 2.4.1)

--- a/gemfiles/Gemfile.elasticsearch-1.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-1.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.4.1)
+    esse (0.5.0)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-2.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-2.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.4.1)
+    esse (0.5.0)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-5.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-5.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.4.1)
+    esse (0.5.0)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-6.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-6.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.4.1)
+    esse (0.5.0)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-7.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-7.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.4.1)
+    esse (0.5.0)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-8.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-8.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.4.1)
+    esse (0.5.0)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.opensearch-1.x.lock
+++ b/gemfiles/Gemfile.opensearch-1.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.4.1)
+    esse (0.5.0)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.opensearch-2.x.lock
+++ b/gemfiles/Gemfile.opensearch-2.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.4.1)
+    esse (0.5.0)
       multi_json
       thor (>= 0.19)
 

--- a/lib/esse/import/bulk.rb
+++ b/lib/esse/import/bulk.rb
@@ -13,13 +13,16 @@ module Esse
       # In case of timeout error, will retry with an exponential backoff using the following formula:
       #  wait_interval = (retry_count**4) + 15 + (rand(10) * (retry_count + 1)) seconds. It will retry up to max_retries times that is default 4.
       #
-      # Too large bulk requests will be split into multiple requests with only one attempt.
+      # Too large bulk requests will first be split into multiple size-balanced requests; if that still
+      # returns 413, the bulk is retried one document per request as a last resort. Only after a single
+      # document still returns 413 does the error bubble up.
       #
       # @yield [RequestBody] A request body instance
-      def each_request(max_retries: 4, last_retry_in_small_chunks: true)
+      def each_request(max_retries: 4, last_retry_in_small_chunks: true, last_retry_per_document: true)
         # @TODO create indexes when by checking all the index suffixes (if mapping is not empty)
         requests = [optimistic_request]
         retry_count = 0
+        too_large_retry_count = 0
 
         begin
           requests.each do |request|
@@ -37,12 +40,28 @@ module Esse
           sleep(wait_interval)
           retry
         rescue Esse::Transport::RequestEntityTooLargeError => e
-          retry_count += 1
-          raise e if retry_count > 1 # only retry once on this error
-          requests = balance_requests_size(e)
+          too_large_retry_count += 1
+          raise e if too_large_retry_count > 2
+
+          if too_large_retry_count == 1
+            balanced = balance_requests_size(e)
+            if balanced && !balanced.empty?
+              requests = balanced
+              Esse.logger.warn <<~MSG
+                Request entity too large, retrying with a bulk with: #{requests.map(&:bytesize).join(' + ')}.
+                Note that this cause performance degradation, consider adjusting the batch_size of the index or increasing the bulk size.
+              MSG
+              retry
+            end
+            raise e unless last_retry_per_document
+            too_large_retry_count = 2
+          end
+
+          raise e unless last_retry_per_document
+          requests = requests_per_document
           Esse.logger.warn <<~MSG
-            Request entity too large, retrying with a bulk with: #{requests.map(&:bytesize).join(' + ')}.
-            Note that this cause performance degradation, consider adjusting the batch_size of the index or increasing the bulk size.
+            Request entity too large after balancing, retrying one document per request as a last resort.
+            If a single document still exceeds the bulk size, the error will be raised.
           MSG
           retry
         end
@@ -60,11 +79,7 @@ module Esse
       end
 
       def requests_in_small_chunks(chunk_size: 1)
-        arr = []
-        @create.each_slice(chunk_size) { |slice| arr << Import::RequestBodyAsJson.new.tap { |r| r.create = slice } }
-        @index.each_slice(chunk_size) { |slice| arr << Import::RequestBodyAsJson.new.tap { |r| r.index = slice } }
-        @update.each_slice(chunk_size) { |slice| arr << Import::RequestBodyAsJson.new.tap { |r| r.update = slice } }
-        @delete.each_slice(chunk_size) { |slice| arr << Import::RequestBodyAsJson.new.tap { |r| r.delete = slice } }
+        arr = build_per_document_requests(chunk_size: chunk_size)
         Esse.logger.warn <<~MSG
           Retrying the last request in small chunks of #{chunk_size} documents.
           This is a last resort to avoid timeout errors, consider increasing the bulk size or reducing the batch size.
@@ -72,33 +87,49 @@ module Esse
         arr
       end
 
-      # @return [Array<RequestBody>]
-      def balance_requests_size(err)
-        if (bulk_size = err.message.scan(/exceeded.(\d+).bytes/).dig(0, 0).to_i) > 0
-          requests = (@create + @index + @update + @delete).each_with_object([Import::RequestBodyRaw.new]) do |as_json, result|
-            operation, meta = as_json.to_a.first
-            meta = meta.dup
-            data = meta.delete(:data)
-            piece = MultiJson.dump(operation => meta)
-            piece << "\n" << MultiJson.dump(data) if data
-            if piece.bytesize > bulk_size
-              Esse.logger.warn <<~MSG
-                The document #{meta.inspect} size is #{piece.bytesize} bytes, which exceeds the maximum bulk size of #{bulk_size} bytes.
-                Consider increasing the bulk size or reducing the document size. The document will be ignored during this import.
-              MSG
-              next
-            end
+      def requests_per_document
+        build_per_document_requests(chunk_size: 1)
+      end
 
-            if result.last.body.bytesize + piece.bytesize > bulk_size
-              result.push(Import::RequestBodyRaw.new.tap { |r| r.add(operation, piece) })
-            else
-              result[-1].add(operation, piece)
-            end
+      def build_per_document_requests(chunk_size: 1)
+        arr = []
+        @create.each_slice(chunk_size) { |slice| arr << Import::RequestBodyAsJson.new.tap { |r| r.create = slice } }
+        @index.each_slice(chunk_size) { |slice| arr << Import::RequestBodyAsJson.new.tap { |r| r.index = slice } }
+        @update.each_slice(chunk_size) { |slice| arr << Import::RequestBodyAsJson.new.tap { |r| r.update = slice } }
+        @delete.each_slice(chunk_size) { |slice| arr << Import::RequestBodyAsJson.new.tap { |r| r.delete = slice } }
+        arr
+      end
+
+      # @return [Array<RequestBody>, nil] balanced requests, or nil when the error message has no parseable byte limit
+      def balance_requests_size(err)
+        bulk_size = err.message.scan(/exceeded.(\d+).bytes/).dig(0, 0).to_i
+        return nil unless bulk_size > 0
+
+        requests = (@create + @index + @update + @delete).each_with_object([Import::RequestBodyRaw.new]) do |as_json, result|
+          operation, meta = as_json.to_a.first
+          meta = meta.dup
+          data = meta.delete(:data)
+          piece = MultiJson.dump(operation => meta)
+          piece << "\n" << MultiJson.dump(data) if data
+
+          if piece.bytesize > bulk_size
+            Esse.logger.warn <<~MSG
+              The document #{meta.inspect} size is #{piece.bytesize} bytes, which exceeds the maximum bulk size of #{bulk_size} bytes.
+              It will be sent in its own request; if the cluster rejects it, the error will be raised.
+            MSG
+            result.push(Import::RequestBodyRaw.new.tap { |r| r.add(operation, piece) })
+            result.push(Import::RequestBodyRaw.new)
+            next
           end
-          requests.each(&:finalize)
-        else
-          raise err
+
+          if result.last.body.bytesize + piece.bytesize > bulk_size
+            result.push(Import::RequestBodyRaw.new.tap { |r| r.add(operation, piece) })
+          else
+            result[-1].add(operation, piece)
+          end
         end
+        requests.reject! { |r| r.body.empty? }
+        requests.each(&:finalize)
       end
     end
   end

--- a/lib/esse/version.rb
+++ b/lib/esse/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Esse
-  VERSION = '0.4.1'
+  VERSION = '0.5.0'
 end

--- a/spec/esse/import/bulk_spec.rb
+++ b/spec/esse/import/bulk_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe Esse::Import::Bulk do
         ].join("\n"))
       end
 
-      it 'discards documents that are larger than the bulk size' do
+      it 'sends documents larger than the bulk size in their own request instead of discarding them' do
         bulk_size = 200 # 200 bytes
         body = elasticsearch_response_fixture(file: 'bulk_request_too_large', version: '7.x', assigns: { request_size: bulk_size })
 
@@ -147,22 +147,82 @@ RSpec.describe Esse::Import::Bulk do
           requests << request
           raise Esse::Transport::RequestEntityTooLargeError.new(MultiJson.dump(body)) if requests.size == 1
         }
-        expect(requests.size).to eq(3)
+        expect(requests.size).to eq(4)
         expect(requests[0]).to be_an_instance_of(Esse::Import::RequestBodyAsJson)
-        expect(requests[1]).to be_an_instance_of(Esse::Import::RequestBodyRaw)
-        expect(requests[2]).to be_an_instance_of(Esse::Import::RequestBodyRaw)
+        expect(requests[1..]).to all(be_an_instance_of(Esse::Import::RequestBodyRaw))
 
-        expect(requests[1].body).to eq([
+        bodies = requests[1..].map(&:body)
+        expect(bodies).to include([
           %[{"index":{"_id":1}}],
           %[{"name":"#{'Aaa' * 30}"}],
           nil
         ].join("\n"))
-        expect(requests[2].body).to eq([
+        expect(bodies).to include([
+          %[{"create":{"_id":2}}],
+          %[{"name":"#{'Bbbb' * 100}"}],
+          nil
+        ].join("\n"))
+        expect(bodies).to include([
           %[{"update":{"_id":4}}],
           %[{"doc":{"name":"#{'Dddd' * 30}"}}],
           %[{"delete":{"_id":3}}],
           nil
         ].join("\n"))
+      end
+
+      it 'retries one document per request when balanced requests still raise 413' do
+        bulk_size = 500
+        body = elasticsearch_response_fixture(file: 'bulk_request_too_large', version: '7.x', assigns: { request_size: bulk_size })
+
+        requests = []
+        bulk.each_request { |request|
+          requests << request
+          if requests.size <= 2
+            raise Esse::Transport::RequestEntityTooLargeError.new(MultiJson.dump(body))
+          end
+        }
+
+        # 1 optimistic (413) + 1 first balanced (413, breaks loop) + 4 per-document = 6
+        expect(requests.size).to eq(6)
+        expect(requests[0]).to be_an_instance_of(Esse::Import::RequestBodyAsJson)
+        expect(requests[1]).to be_an_instance_of(Esse::Import::RequestBodyRaw)
+        expect(requests[2..]).to all(be_an_instance_of(Esse::Import::RequestBodyAsJson))
+        expect(requests[2..].map { |r| r.body.size }).to all(eq(1))
+      end
+
+      it 'raises when a single-document bulk still returns 413' do
+        bulk_size = 500
+        body = elasticsearch_response_fixture(file: 'bulk_request_too_large', version: '7.x', assigns: { request_size: bulk_size })
+
+        expect {
+          bulk.each_request { |_request|
+            raise Esse::Transport::RequestEntityTooLargeError.new(MultiJson.dump(body))
+          }
+        }.to raise_error(Esse::Transport::RequestEntityTooLargeError)
+      end
+
+      it 'falls through to per-document retry when the 413 message has no parseable size' do
+        requests = []
+        bulk.each_request { |request|
+          requests << request
+          raise Esse::Transport::RequestEntityTooLargeError.new('payload too large') if requests.size == 1
+        }
+
+        # 1 optimistic + 4 per-document = 5
+        expect(requests.size).to eq(5)
+        expect(requests[0]).to be_an_instance_of(Esse::Import::RequestBodyAsJson)
+        expect(requests[1..]).to all(be_an_instance_of(Esse::Import::RequestBodyAsJson))
+        expect(requests[1..].map { |r| r.body.size }).to all(eq(1))
+      end
+
+      it 'does not retry per-document when last_retry_per_document is false' do
+        body = elasticsearch_response_fixture(file: 'bulk_request_too_large', version: '7.x', assigns: { request_size: 500 })
+
+        expect {
+          bulk.each_request(last_retry_per_document: false) { |request|
+            raise Esse::Transport::RequestEntityTooLargeError.new(MultiJson.dump(body))
+          }
+        }.to raise_error(Esse::Transport::RequestEntityTooLargeError)
       end
     end
   end


### PR DESCRIPTION
## Summary

When a bulk import receives `RequestEntityTooLargeError` (HTTP 413), `Esse::Import::Bulk#each_request` already retries once with size-balanced chunks (`balance_requests_size`). If that retry still 413s, the error currently bubbles up and aborts the whole import — even though one or two oversized documents in the batch may be the only problem.

This PR adds a third recovery tier: after the balanced retry, the bulk is split **one document per request** as a last resort. The error is only raised once a single-document bulk still exceeds the limit (which is the only case where the data is genuinely unimportable).

Changes:
- New per-document retry tier after `balance_requests_size`, with a distinct warning so the fallback is observable.
- Per-document retry also triggers when the 413 message has no parseable byte limit (previously `balance_requests_size` re-raised immediately, defeating retry).
- Oversized single documents are no longer silently discarded — they're sent in their own request, so the eventual 413 from the cluster identifies them.
- New `last_retry_per_document: true` keyword arg on `each_request` to opt out.
- Version bumped to `0.5.0`; all `Gemfile.lock` files refreshed.

## Test plan

- [x] `bundle exec rspec spec/esse/import/bulk_spec.rb` — 11 examples, 0 failures (includes 4 new examples + 1 updated for the changed discard behavior)
- [x] Full unit suite (`STUB_STACK=elasticsearch-7.17.0 BUNDLE_GEMFILE=gemfiles/Gemfile.elasticsearch-7.x bundle exec rspec --exclude-pattern 'spec/esse/integrations/**/*'`) — 1017 examples, 0 failures