### PR TITLE
Retry bulk import on transient server errors (502/503/504/429)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    esse (0.5.0)
+    esse (0.5.1)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-1.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-1.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.5.0)
+    esse (0.5.1)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-2.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-2.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.5.0)
+    esse (0.5.1)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-5.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-5.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.5.0)
+    esse (0.5.1)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-6.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-6.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.5.0)
+    esse (0.5.1)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-7.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-7.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.5.0)
+    esse (0.5.1)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-8.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-8.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.5.0)
+    esse (0.5.1)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.opensearch-1.x.lock
+++ b/gemfiles/Gemfile.opensearch-1.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.5.0)
+    esse (0.5.1)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.opensearch-2.x.lock
+++ b/gemfiles/Gemfile.opensearch-2.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.5.0)
+    esse (0.5.1)
       multi_json
       thor (>= 0.19)
 

--- a/lib/esse/config.rb
+++ b/lib/esse/config.rb
@@ -43,7 +43,7 @@ module Esse
   #   end
   class Config
     DEFAULT_CLUSTER_ID = :default
-    ATTRIBUTES = %i[indices_directory bulk_wait_interval].freeze
+    ATTRIBUTES = %i[indices_directory bulk_wait_interval bulk_retry_on_failure_max_retries bulk_retry_on_failure_wait].freeze
 
     # The location of the indices. Defaults to the `app/indices`
     attr_reader :indices_directory
@@ -51,9 +51,17 @@ module Esse
     # wait a given period between posting pages to give Elasticsearch time to catch up.
     attr_reader :bulk_wait_interval
 
+    # number of retries on transient server errors (502, 503, 504, 429) before raising
+    attr_reader :bulk_retry_on_failure_max_retries
+
+    # base wait in seconds between transient-error retries (doubles each attempt)
+    attr_reader :bulk_retry_on_failure_wait
+
     def initialize
       self.indices_directory = 'app/indices'
       self.bulk_wait_interval = 0.1
+      self.bulk_retry_on_failure_max_retries = 3
+      self.bulk_retry_on_failure_wait = 2.0
       @clusters = {}
       cluster(DEFAULT_CLUSTER_ID) # initialize the :default client
     end
@@ -79,6 +87,14 @@ module Esse
 
     def bulk_wait_interval=(value)
       @bulk_wait_interval = value.to_f
+    end
+
+    def bulk_retry_on_failure_max_retries=(value)
+      @bulk_retry_on_failure_max_retries = value.to_i
+    end
+
+    def bulk_retry_on_failure_wait=(value)
+      @bulk_retry_on_failure_wait = value.to_f
     end
 
     def load(arg)

--- a/lib/esse/errors.rb
+++ b/lib/esse/errors.rb
@@ -57,6 +57,7 @@ module Esse
       'ExpectationFailed' => 'ExpectationFailedError', # 417
       'ImATeapot' => 'ImATeapotError', # 418
       'TooManyConnectionsFromThisIP' => 'TooManyConnectionsFromThisIPError', # 421
+      'TooManyRequests' => 'TooManyRequestsError', # 429
       'UpgradeRequired' => 'UpgradeRequiredError', # 426
       'BlockedByWindowsParentalControls' => 'BlockedByWindowsParentalControlsError', # 450
       'RequestHeaderTooLarge' => 'RequestHeaderTooLargeError', # 494

--- a/lib/esse/import/bulk.rb
+++ b/lib/esse/import/bulk.rb
@@ -18,11 +18,13 @@ module Esse
       # document still returns 413 does the error bubble up.
       #
       # @yield [RequestBody] A request body instance
-      def each_request(max_retries: 4, last_retry_in_small_chunks: true, last_retry_per_document: true)
+      def each_request(max_retries: 4, last_retry_in_small_chunks: true, last_retry_per_document: true,
+                       retry_on_failure_max_retries: 3, retry_on_failure_wait: 2.0)
         # @TODO create indexes when by checking all the index suffixes (if mapping is not empty)
         requests = [optimistic_request]
         retry_count = 0
         too_large_retry_count = 0
+        transient_failure_count = 0
 
         begin
           requests.each do |request|
@@ -63,6 +65,16 @@ module Esse
             Request entity too large after balancing, retrying one document per request as a last resort.
             If a single document still exceeds the bulk size, the error will be raised.
           MSG
+          retry
+        rescue Esse::Transport::BadGatewayError,
+               Esse::Transport::ServiceUnavailableError,
+               Esse::Transport::GatewayTimeoutError,
+               Esse::Transport::TooManyRequestsError => e
+          transient_failure_count += 1
+          raise e if transient_failure_count >= retry_on_failure_max_retries
+          wait = retry_on_failure_wait * (2**(transient_failure_count - 1))
+          Esse.logger.warn "#{e.class} error, retrying in #{wait}s (attempt #{transient_failure_count}/#{retry_on_failure_max_retries})"
+          sleep(wait)
           retry
         end
       end

--- a/lib/esse/index/attributes.rb
+++ b/lib/esse/index/attributes.rb
@@ -72,6 +72,22 @@ module Esse
         @bulk_wait_interval = value.to_f
       end
 
+      def bulk_retry_on_failure_max_retries
+        @bulk_retry_on_failure_max_retries || Esse.config.bulk_retry_on_failure_max_retries
+      end
+
+      def bulk_retry_on_failure_max_retries=(value)
+        @bulk_retry_on_failure_max_retries = value.to_i
+      end
+
+      def bulk_retry_on_failure_wait
+        @bulk_retry_on_failure_wait || Esse.config.bulk_retry_on_failure_wait
+      end
+
+      def bulk_retry_on_failure_wait=(value)
+        @bulk_retry_on_failure_wait = value.to_f
+      end
+
       def mapping_single_type=(value)
         @mapping_single_type = !!value
       end

--- a/lib/esse/index/documents.rb
+++ b/lib/esse/index/documents.rb
@@ -256,7 +256,10 @@ module Esse
           delete: to_delete,
           index: to_index,
           update: to_update,
-        ).each_request do |request_body|
+        ).each_request(
+          retry_on_failure_max_retries: bulk_retry_on_failure_max_retries,
+          retry_on_failure_wait: bulk_retry_on_failure_wait,
+        ) do |request_body|
           cluster.api.bulk(**definition, body: request_body.body) do |event_payload|
             event_payload[:body_stats] = request_body.stats
             if bulk_wait_interval > 0

--- a/lib/esse/version.rb
+++ b/lib/esse/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Esse
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 end

--- a/spec/esse/import/bulk_spec.rb
+++ b/spec/esse/import/bulk_spec.rb
@@ -68,6 +68,51 @@ RSpec.describe Esse::Import::Bulk do
       expect(retries).to eq(3)
     end
 
+    it 'retries on transient server errors and eventually raises' do
+      expect(bulk).to receive(:sleep).with(2.0).once
+      expect(bulk).to receive(:sleep).with(4.0).once
+      expect(Esse.logger).to receive(:warn).with(an_instance_of(String)).twice
+      retries = 0
+      expect {
+        bulk.each_request(retry_on_failure_max_retries: 3, retry_on_failure_wait: 2.0) { |_request|
+          retries += 1
+          raise Esse::Transport::BadGatewayError
+        }
+      }.to raise_error(Esse::Transport::BadGatewayError)
+      expect(retries).to eq(3)
+    end
+
+    it 'retries all transient server error classes' do
+      [
+        Esse::Transport::BadGatewayError,
+        Esse::Transport::ServiceUnavailableError,
+        Esse::Transport::GatewayTimeoutError,
+        Esse::Transport::TooManyRequestsError,
+      ].each do |error_class|
+        allow(bulk).to receive(:sleep)
+        allow(Esse.logger).to receive(:warn)
+        retries = 0
+        expect {
+          bulk.each_request(retry_on_failure_max_retries: 2, retry_on_failure_wait: 0) { |_request|
+            retries += 1
+            raise error_class
+          }
+        }.to raise_error(error_class)
+        expect(retries).to eq(2)
+      end
+    end
+
+    it 'succeeds when transient error resolves before threshold' do
+      allow(bulk).to receive(:sleep)
+      allow(Esse.logger).to receive(:warn)
+      call_count = 0
+      bulk.each_request(retry_on_failure_max_retries: 3, retry_on_failure_wait: 0) { |_request|
+        call_count += 1
+        raise Esse::Transport::ServiceUnavailableError if call_count == 1
+      }
+      expect(call_count).to eq(2)
+    end
+
     context 'without data' do
       let(:index) { [] }
       let(:create) { [] }


### PR DESCRIPTION
## Summary

- Catches `BadGatewayError` (502), `ServiceUnavailableError` (503), `GatewayTimeoutError` (504), and `TooManyRequestsError` (429) during bulk import and retries with exponential backoff before raising
- Backoff schedule (default): 2s → 4s → raises on 3rd failure
- Adds `TooManyRequestsError` (429) to the transport error mapping (was missing)
- New config options `bulk_retry_on_failure_max_retries` (default: 3) and `bulk_retry_on_failure_wait` (default: 2.0s) — settable globally or per-index, consistent with existing `bulk_wait_interval` pattern
- Bumps version to 0.5.1, updates all Gemfile locks

## Test plan

- [x] `bundle exec rspec spec/esse/import/bulk_spec.rb` — 14 examples, 0 failures
- [x] `STUB_STACK=elasticsearch-7.17.0 BUNDLE_GEMFILE=gemfiles/Gemfile.elasticsearch-7.x bundle exec rspec` — 2245 examples, 0 failures