### PR TITLE
Include document IDs in per-document retry warnings (v0.5.2)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    esse (0.5.1)
+    esse (0.5.2)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-1.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-1.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.5.1)
+    esse (0.5.2)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-2.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-2.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.5.1)
+    esse (0.5.2)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-5.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-5.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.5.1)
+    esse (0.5.2)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-6.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-6.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.5.1)
+    esse (0.5.2)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-7.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-7.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.5.1)
+    esse (0.5.2)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-8.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-8.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.5.1)
+    esse (0.5.2)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.opensearch-1.x.lock
+++ b/gemfiles/Gemfile.opensearch-1.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.5.1)
+    esse (0.5.2)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.opensearch-2.x.lock
+++ b/gemfiles/Gemfile.opensearch-2.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.5.1)
+    esse (0.5.2)
       multi_json
       thor (>= 0.19)
 

--- a/lib/esse/import/bulk.rb
+++ b/lib/esse/import/bulk.rb
@@ -61,8 +61,10 @@ module Esse
 
           raise e unless last_retry_per_document
           requests = requests_per_document
+          ids = document_ids
+          id_info = ids.any? ? " (document IDs: #{ids.join(', ')})" : ''
           Esse.logger.warn <<~MSG
-            Request entity too large after balancing, retrying one document per request as a last resort.
+            Request entity too large after balancing, retrying one document per request as a last resort#{id_info}.
             If a single document still exceeds the bulk size, the error will be raised.
           MSG
           retry
@@ -92,15 +94,21 @@ module Esse
 
       def requests_in_small_chunks(chunk_size: 1)
         arr = build_per_document_requests(chunk_size: chunk_size)
+        ids = document_ids
+        id_info = ids.any? ? " (document IDs: #{ids.join(', ')})" : ''
         Esse.logger.warn <<~MSG
-          Retrying the last request in small chunks of #{chunk_size} documents.
-          This is a last resort to avoid timeout errors, consider increasing the bulk size or reducing the batch size.
+          Timeout error, retrying one document per request as a last resort#{id_info}.
+          Consider increasing the bulk size or reducing the batch size.
         MSG
         arr
       end
 
       def requests_per_document
         build_per_document_requests(chunk_size: 1)
+      end
+
+      def document_ids
+        (@create + @index + @update + @delete).filter_map { |op| op.values.first[:_id] }
       end
 
       def build_per_document_requests(chunk_size: 1)

--- a/lib/esse/version.rb
+++ b/lib/esse/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Esse
-  VERSION = '0.5.1'
+  VERSION = '0.5.2'
 end

--- a/spec/esse/import/bulk_spec.rb
+++ b/spec/esse/import/bulk_spec.rb
@@ -145,6 +145,20 @@ RSpec.describe Esse::Import::Bulk do
         }
         expect(requests.size).to eq(3 + index.size + create.size + delete.size)
       end
+
+      it 'includes document IDs in the timeout per-document retry warning' do
+        warnings = []
+        allow(Esse.logger).to receive(:warn) { |msg| warnings << msg }
+        allow(bulk).to receive(:sleep)
+        requests = []
+        bulk.each_request(last_retry_in_small_chunks: true) { |request|
+          requests << request
+          raise Faraday::TimeoutError if requests.size <= 2
+        }
+        small_chunk_warning = warnings.find { |w| w.include?('one document per request') }
+        expect(small_chunk_warning).to include('document IDs:')
+        expect(small_chunk_warning).to include('10', '11', '12')
+      end
     end
 
     context 'with a request entity too large error' do
@@ -258,6 +272,15 @@ RSpec.describe Esse::Import::Bulk do
         expect(requests[0]).to be_an_instance_of(Esse::Import::RequestBodyAsJson)
         expect(requests[1..]).to all(be_an_instance_of(Esse::Import::RequestBodyAsJson))
         expect(requests[1..].map { |r| r.body.size }).to all(eq(1))
+      end
+
+      it 'includes document IDs in the per-document retry warning' do
+        warning = nil
+        allow(Esse.logger).to receive(:warn) { |msg| warning = msg }
+        bulk.each_request { |request|
+          raise Esse::Transport::RequestEntityTooLargeError.new('payload too large') if warning.nil?
+        }
+        expect(warning).to include('document IDs: 2, 1, 4, 3')
       end
 
       it 'does not retry per-document when last_retry_per_document is false' do


### PR DESCRIPTION
## Summary

- When bulk import falls back to one-request-per-document (on 413 *Request Entity Too Large* or timeout), the warning log now includes document IDs when available — e.g. `(document IDs: 42, 99, 137)` — making oversized/problematic documents immediately identifiable
- Clarifies the timeout fallback warning: was `"Retrying the last request in small chunks of 1 documents"` (confusing), now `"Timeout error, retrying one document per request as a last resort"` (explicit)
- Note: the timeout path **already** used 1-doc-per-request; only the message was misleading
- Bumps version to 0.5.2, updates all Gemfile locks

## Test plan

- [x] `STUB_STACK=elasticsearch-7.17.0 BUNDLE_GEMFILE=gemfiles/Gemfile.elasticsearch-7.x bundle exec rspec spec/esse/import/bulk_spec.rb` — 16 examples, 0 failures