### PR TITLE
Retry on Faraday::ConnectionFailed (DNS/TCP transient errors) v0.5.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    esse (0.5.2)
+    esse (0.5.3)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-1.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-1.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.5.2)
+    esse (0.5.3)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-2.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-2.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.5.2)
+    esse (0.5.3)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-5.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-5.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.5.2)
+    esse (0.5.3)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-6.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-6.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.5.2)
+    esse (0.5.3)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-7.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-7.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.5.2)
+    esse (0.5.3)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.elasticsearch-8.x.lock
+++ b/gemfiles/Gemfile.elasticsearch-8.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.5.2)
+    esse (0.5.3)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.opensearch-1.x.lock
+++ b/gemfiles/Gemfile.opensearch-1.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.5.2)
+    esse (0.5.3)
       multi_json
       thor (>= 0.19)
 

--- a/gemfiles/Gemfile.opensearch-2.x.lock
+++ b/gemfiles/Gemfile.opensearch-2.x.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    esse (0.5.2)
+    esse (0.5.3)
       multi_json
       thor (>= 0.19)
 

--- a/lib/esse/import/bulk.rb
+++ b/lib/esse/import/bulk.rb
@@ -68,7 +68,8 @@ module Esse
             If a single document still exceeds the bulk size, the error will be raised.
           MSG
           retry
-        rescue Esse::Transport::BadGatewayError,
+        rescue Faraday::ConnectionFailed,
+               Esse::Transport::BadGatewayError,
                Esse::Transport::ServiceUnavailableError,
                Esse::Transport::GatewayTimeoutError,
                Esse::Transport::TooManyRequestsError => e

--- a/lib/esse/version.rb
+++ b/lib/esse/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Esse
-  VERSION = '0.5.2'
+  VERSION = '0.5.3'
 end

--- a/spec/esse/import/bulk_spec.rb
+++ b/spec/esse/import/bulk_spec.rb
@@ -84,6 +84,7 @@ RSpec.describe Esse::Import::Bulk do
 
     it 'retries all transient server error classes' do
       [
+        Faraday::ConnectionFailed,
         Esse::Transport::BadGatewayError,
         Esse::Transport::ServiceUnavailableError,
         Esse::Transport::GatewayTimeoutError,

--- a/spec/esse/import/bulk_spec.rb
+++ b/spec/esse/import/bulk_spec.rb
@@ -84,7 +84,6 @@ RSpec.describe Esse::Import::Bulk do
 
     it 'retries all transient server error classes' do
       [
-        Faraday::ConnectionFailed,
         Esse::Transport::BadGatewayError,
         Esse::Transport::ServiceUnavailableError,
         Esse::Transport::GatewayTimeoutError,
@@ -101,6 +100,19 @@ RSpec.describe Esse::Import::Bulk do
         }.to raise_error(error_class)
         expect(retries).to eq(2)
       end
+    end
+
+    it 'retries on Faraday::ConnectionFailed' do
+      allow(bulk).to receive(:sleep)
+      allow(Esse.logger).to receive(:warn)
+      retries = 0
+      expect {
+        bulk.each_request(retry_on_failure_max_retries: 2, retry_on_failure_wait: 0) { |_request|
+          retries += 1
+          raise Faraday::ConnectionFailed, RuntimeError.new('getaddrinfo: Try again')
+        }
+      }.to raise_error(Faraday::ConnectionFailed)
+      expect(retries).to eq(2)
     end
 
     it 'succeeds when transient error resolves before threshold' do


### PR DESCRIPTION
## Summary

`Faraday::ConnectionFailed` (DNS resolution failure, TCP connection refused) was crashing import jobs instead of retrying. This adds it to the existing transient-error rescue block alongside 502/503/504/429, so it retries with the same exponential backoff (2s → 4s → raises).

Example error that is now retried:
```
Faraday::ConnectionFailed: Failed to open TCP connection to pipeline.oss.locallabs.com:443 (getaddrinfo: Try again)
```

Bumps version to 0.5.3, updates all Gemfile locks.

## Test plan

- [x] `STUB_STACK=elasticsearch-7.17.0 BUNDLE_GEMFILE=gemfiles/Gemfile.elasticsearch-7.x bundle exec rspec spec/esse/import/bulk_spec.rb` — 16 examples, 0 failures